### PR TITLE
Add Has Dropped

### DIFF
--- a/components/cards/ProjectCard/ProjectCard.tsx
+++ b/components/cards/ProjectCard/ProjectCard.tsx
@@ -79,7 +79,7 @@ const ProjectCard: FC<Props> = ({ project }) => {
                   },
                 }}
               >
-                {`${project.name}`}
+                {`${project.teamName}`}
               </Typography>
             </Link>
             <Box
@@ -98,7 +98,7 @@ const ProjectCard: FC<Props> = ({ project }) => {
                 src={
                   "https://nusskylab-dev.comp.nus.edu.sg/posters/2021/2680.jpg"
                 }
-                alt={`${project.name} Project`}
+                alt={`${project.teamName} Project`}
                 sx={{
                   width: "100%",
                   objectFit: "cover",

--- a/components/formikFormControllers/Checkbox/Checkbox.tsx
+++ b/components/formikFormControllers/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import {
   FormControlLabel,
   FormGroup,
-  Checkbox as MuiCheckbox,
+  Checkbox as MUICheckbox,
   FormHelperText,
 } from "@mui/material";
 import { FormikProps } from "formik";
@@ -23,7 +23,7 @@ function Checkbox<FormValuesType>({
     <FormGroup>
       <FormControlLabel
         control={
-          <MuiCheckbox
+          <MUICheckbox
             checked={!!values[name]}
             name={name as string}
             onChange={handleChange}

--- a/components/formikFormControllers/Switch/Switch.tsx
+++ b/components/formikFormControllers/Switch/Switch.tsx
@@ -1,0 +1,39 @@
+import { FormControlLabel, Switch as MUISwitch } from "@mui/material";
+import { FormikProps } from "formik";
+
+type Props<FormValuesType> = {
+  label: string;
+  name: keyof FormValuesType;
+  formik: FormikProps<FormValuesType>;
+  isDisabled?: boolean;
+  labelPlacement?: "start";
+};
+
+function Switch<FormValuesType>({
+  label,
+  name,
+  formik,
+  isDisabled = false,
+  labelPlacement,
+}: Props<FormValuesType>) {
+  const { values, handleChange, handleBlur } = formik;
+
+  return (
+    <FormControlLabel
+      control={
+        <MUISwitch
+          color="secondary"
+          size="small"
+          value={values[name]}
+          name={name as string}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          disabled={isDisabled}
+        />
+      }
+      label={label}
+      labelPlacement={labelPlacement}
+    />
+  );
+}
+export default Switch;

--- a/components/formikFormControllers/Switch/index.tsx
+++ b/components/formikFormControllers/Switch/index.tsx
@@ -1,0 +1,2 @@
+import Switch from "./Switch";
+export default Switch;

--- a/components/modals/AddProjectModal/AddProjectModal.tsx
+++ b/components/modals/AddProjectModal/AddProjectModal.tsx
@@ -33,6 +33,7 @@ import { Cohort } from "@/types/cohorts";
 
 interface AddProjectFormValuesType {
   name: string;
+  teamName: string;
   achievement: LEVELS_OF_ACHIEVEMENT;
   students: number[];
   adviser: number | "";
@@ -71,6 +72,7 @@ const AddProjectModal: FC<Props> = ({ open, setOpen, mutate }) => {
 
   const initialValues: AddProjectFormValuesType = {
     name: "",
+    teamName: "",
     achievement: LEVELS_OF_ACHIEVEMENT.VOSTOK,
     students: [],
     adviser: "",
@@ -153,6 +155,12 @@ const AddProjectModal: FC<Props> = ({ open, setOpen, mutate }) => {
                 <TextInput
                   name="name"
                   label="Project Name"
+                  size="small"
+                  formik={formik}
+                />
+                <TextInput
+                  name="teamName"
+                  label="Team Name"
                   size="small"
                   formik={formik}
                 />

--- a/components/modals/ProjectSubmissionModal/ProjectSubmissionModal.tsx
+++ b/components/modals/ProjectSubmissionModal/ProjectSubmissionModal.tsx
@@ -16,7 +16,7 @@ const ProjectSubmissionModal: FC<Props> = ({ open, setOpen, project }) => {
     <Modal
       open={open}
       handleClose={handleClose}
-      title={`Project ${project.id}: ${project.name}`}
+      title={`Project ${project.id}: ${project.teamName}`}
       sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
     >
       <Typography variant="h6" align="center" fontWeight={600} mb="0.5rem">
@@ -32,7 +32,7 @@ const ProjectSubmissionModal: FC<Props> = ({ open, setOpen, project }) => {
         <Box
           src={"https://nusskylab-dev.comp.nus.edu.sg/posters/2021/2680.jpg"}
           component="img"
-          alt={`${project.name} Poster`}
+          alt={`${project.teamName} Poster`}
         />
       </Box>
 

--- a/components/tables/ProjectTable/ProjectRow/ProjectRow.tsx
+++ b/components/tables/ProjectTable/ProjectRow/ProjectRow.tsx
@@ -81,7 +81,7 @@ const ProjectRow: FC<Props> = ({ project, mutate, setSuccess, setError }) => {
       />
       <TableRow>
         <TableCell>{project.id}</TableCell>
-        <TableCell>{project.teamName}</TableCell>
+        <TableCell>{project.name}</TableCell>
         <TableCell>
           <Stack direction="row" spacing="0.25rem">
             {renderTag()}

--- a/components/tables/ProjectTable/ProjectRow/ProjectRow.tsx
+++ b/components/tables/ProjectTable/ProjectRow/ProjectRow.tsx
@@ -81,7 +81,7 @@ const ProjectRow: FC<Props> = ({ project, mutate, setSuccess, setError }) => {
       />
       <TableRow>
         <TableCell>{project.id}</TableCell>
-        <TableCell>{project.name}</TableCell>
+        <TableCell>{project.teamName}</TableCell>
         <TableCell>
           <Stack direction="row" spacing="0.25rem">
             {renderTag()}

--- a/hooks/useFetch/useFetch.helpers.ts
+++ b/hooks/useFetch/useFetch.helpers.ts
@@ -49,11 +49,11 @@ export function parseQueryParams(queryParams: QueryParams | undefined): string {
   let numberOfInvalidParams = 0;
 
   for (const [query, param] of Object.entries(queryParamsCopy)) {
-    if (param instanceof Array) {
+    if (Array.isArray(param)) {
       for (const val of param) {
         parsedQueryParams += `${query}=${val}&`;
       }
-    } else if (param !== undefined && param !== "") {
+    } else if (param !== undefined && param !== null && param !== "") {
       parsedQueryParams += `${query}=${param}&`;
     } else {
       numberOfInvalidParams++;

--- a/hooks/useFetch/useFetch.helpers.ts
+++ b/hooks/useFetch/useFetch.helpers.ts
@@ -53,7 +53,7 @@ export function parseQueryParams(queryParams: QueryParams | undefined): string {
       for (const val of param) {
         parsedQueryParams += `${query}=${val}&`;
       }
-    } else if (typeof param === "number" || param) {
+    } else if (param !== undefined && param !== "") {
       parsedQueryParams += `${query}=${param}&`;
     } else {
       numberOfInvalidParams++;

--- a/pages/manage/projects.tsx
+++ b/pages/manage/projects.tsx
@@ -129,6 +129,7 @@ const ProjectsList = () => {
 
   const handleToggleViewDropped = () => {
     setViewHasDropped(!viewHasDropped);
+    setPage(0);
   };
 
   /** To fetch more projects when the bottom of the page is reached */

--- a/pages/manage/projects.tsx
+++ b/pages/manage/projects.tsx
@@ -73,7 +73,7 @@ const ProjectsList = () => {
           : selectedLevelOfAchievement,
       search: querySearch,
       limit: LIMIT,
-      hasDropped: viewHasDropped,
+      dropped: viewHasDropped,
     };
   }, [
     selectedCohortYear,

--- a/pages/manage/projects.tsx
+++ b/pages/manage/projects.tsx
@@ -20,8 +20,10 @@ import {
   Box,
   Button,
   debounce,
+  FormControlLabel,
   MenuItem,
   Stack,
+  Switch,
   Tab,
   Tabs,
   tabsClasses,
@@ -44,10 +46,9 @@ import { ROLES } from "@/types/roles";
 const LIMIT = 20;
 
 const ProjectsList = () => {
-  const [selectedLevelOfAchievement, setSelectedLevelOfAchievement] =
-    useState<LEVELS_OF_ACHIEVEMENT_WITH_ALL>(
-      LEVELS_OF_ACHIEVEMENT_WITH_ALL.ALL
-    );
+  const [selectedLevelOfAchievement, setSelectedLevelOfAchievement] = useState(
+    LEVELS_OF_ACHIEVEMENT_WITH_ALL.ALL
+  );
   const [page, setPage] = useState(0);
   const [searchTextInput, setSearchTextInput] = useState(""); // The input value
   const [querySearch, setQuerySearch] = useState(""); // The debounced input value for searching
@@ -57,8 +58,9 @@ const ProjectsList = () => {
     isLoading: isLoadingCohorts,
   } = useCohort();
   const [selectedCohortYear, setSelectedCohortYear] = useState<
-    Cohort["academicYear"] | string
+    Cohort["academicYear"] | ""
   >("");
+  const [viewHasDropped, setViewHasDropped] = useState(false);
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
 
   /** For fetching projects based on filters */
@@ -71,8 +73,14 @@ const ProjectsList = () => {
           : selectedLevelOfAchievement,
       search: querySearch,
       limit: LIMIT,
+      hasDropped: viewHasDropped,
     };
-  }, [selectedCohortYear, selectedLevelOfAchievement, querySearch]);
+  }, [
+    selectedCohortYear,
+    selectedLevelOfAchievement,
+    querySearch,
+    viewHasDropped,
+  ]);
 
   const {
     data: projects,
@@ -117,6 +125,10 @@ const ProjectsList = () => {
 
   const handleOpenAddProjectModal = () => {
     setIsAddProjectOpen(true);
+  };
+
+  const handleToggleViewDropped = () => {
+    setViewHasDropped(!viewHasDropped);
   };
 
   /** To fetch more projects when the bottom of the page is reached */
@@ -187,24 +199,33 @@ const ProjectsList = () => {
             </Stack>
           </Stack>
 
-          <Tabs
-            value={selectedLevelOfAchievement}
-            onChange={handleTabChange}
-            textColor="secondary"
-            indicatorColor="secondary"
-            aria-label="project-level-tabs"
-            variant="scrollable"
-            scrollButtons="auto"
-            allowScrollButtonsMobile
-            sx={{
-              [`& .${tabsClasses.scrollButtons}`]: { color: "primary" },
-              marginY: { xs: 2, md: 0 },
-            }}
-          >
-            {Object.values(LEVELS_OF_ACHIEVEMENT_WITH_ALL).map((level) => {
-              return <Tab key={level} value={level} label={level} />;
-            })}
-          </Tabs>
+          <Stack direction="row" justifyContent="space-between">
+            <Tabs
+              value={selectedLevelOfAchievement}
+              onChange={handleTabChange}
+              textColor="secondary"
+              indicatorColor="secondary"
+              aria-label="project-level-tabs"
+              variant="scrollable"
+              scrollButtons="auto"
+              allowScrollButtonsMobile
+              sx={{
+                [`& .${tabsClasses.scrollButtons}`]: { color: "primary" },
+                marginY: { xs: 2, md: 0 },
+              }}
+            >
+              {Object.values(LEVELS_OF_ACHIEVEMENT_WITH_ALL).map((level) => {
+                return <Tab key={level} value={level} label={level} />;
+              })}
+            </Tabs>
+            <FormControlLabel
+              value={viewHasDropped}
+              onClick={handleToggleViewDropped}
+              control={<Switch color="secondary" size="small" />}
+              label="View Dropped Projects"
+              labelPlacement="start"
+            />
+          </Stack>
         </Stack>
         <LoadingWrapper
           isLoading={

--- a/pages/manage/users/batch-add.tsx
+++ b/pages/manage/users/batch-add.tsx
@@ -19,11 +19,6 @@ import BatchAddMentorsForm, {
   ADD_MENTORS_CSV_HEADERS,
   processBatchAddMentorsData,
 } from "@/components/batchForms/BatchAddMentorsForm";
-import BatchAttachAdvisersForm, {
-  processBatchAdviserData,
-  ATTACH_ADVISERS_CSV_HEADERS,
-  AttachAdvisersData,
-} from "@/components/batchForms/BatchAttachAdvisersForm";
 import { Box, Stack } from "@mui/material";
 // Hooks
 import useApiCall from "@/hooks/useApiCall";
@@ -109,30 +104,6 @@ const BatchAdd: NextPage = () => {
     setAddAdvisersData([]);
   };
 
-  /** Attach Advisers Functions */
-  const [attachAdvisersData, setAttachAdvisersData] =
-    useState<AttachAdvisersData>([]);
-  const batchAttachAdvisers = useApiCall({
-    method: HTTP_METHOD.POST,
-    endpoint: `/users/attach-adviser/batch`,
-    requiresAuthorization: true,
-  });
-
-  const handleAttachAdvisers = async () => {
-    try {
-      const processedValues = processBatchAdviserData(attachAdvisersData);
-      await batchAttachAdvisers.call(processedValues);
-      setSuccess("Successfully attached the advisers!");
-      handleClearAttachAdvisers();
-    } catch (error) {
-      setError(error);
-    }
-  };
-
-  const handleClearAttachAdvisers = () => {
-    setAttachAdvisersData([]);
-  };
-
   return (
     <>
       <SnackbarAlert snackbar={snackbar} handleClose={handleClose} />
@@ -178,19 +149,6 @@ const BatchAdd: NextPage = () => {
               handleAddMentors={handleAddMentors}
               handleClearAddMentors={handleClearAddMentors}
               isSubmitting={isCalling(batchAddMentors.status)}
-            />
-          </Box>
-          <Box>
-            <HeadingWithCsvTemplate
-              title="Batch Attach Advisers"
-              tooltipText="This attaches an adviser role onto EXISTING users (with a past student role) via their NUSNET ID"
-              csvTemplateHeaders={[Object.values(ATTACH_ADVISERS_CSV_HEADERS)]}
-            />
-            <BatchAttachAdvisersForm
-              setAttachAdvisersData={setAttachAdvisersData}
-              handleAttachAdvisers={handleAttachAdvisers}
-              handleClearAttachAdvisers={handleClearAttachAdvisers}
-              isSubmitting={isCalling(batchAttachAdvisers.status)}
             />
           </Box>
         </Stack>

--- a/pages/manage/users/index.tsx
+++ b/pages/manage/users/index.tsx
@@ -92,6 +92,7 @@ const Users: NextPage = () => {
   const memoLeanProjectsQueryParams = useMemo(() => {
     return {
       cohortYear: selectedCohortYear,
+      dropped: false,
     };
   }, [selectedCohortYear]);
   const { data: leanProjectsResponse, status: fetchLeanProjectsStatus } =

--- a/pages/projects/[projectId]/edit.tsx
+++ b/pages/projects/[projectId]/edit.tsx
@@ -36,7 +36,7 @@ import Switch from "@/components/formikFormControllers/Switch";
 
 type EditProjectFormValues = Pick<
   Project,
-  "name" | "achievement" | "proposalPdf" | "hasDropped"
+  "name" | "teamName" | "achievement" | "proposalPdf" | "hasDropped"
 > & { students: number[]; adviser: number | ""; mentor: number | "" };
 
 const EditProject: NextPage = () => {
@@ -54,6 +54,7 @@ const EditProject: NextPage = () => {
 
   const initialValues: EditProjectFormValues = {
     name: project?.name ?? "",
+    teamName: project?.name ?? "",
     achievement: project?.achievement ?? LEVELS_OF_ACHIEVEMENT.VOSTOK,
     proposalPdf: project?.proposalPdf ?? "",
     students: project?.students
@@ -135,6 +136,11 @@ const EditProject: NextPage = () => {
                           <TextInput
                             name="name"
                             label="Project Name"
+                            formik={formik}
+                          />
+                          <TextInput
+                            name="teamName"
+                            label="Team Name"
                             formik={formik}
                           />
                           <Dropdown

--- a/pages/projects/[projectId]/edit.tsx
+++ b/pages/projects/[projectId]/edit.tsx
@@ -32,10 +32,11 @@ import { checkIfProjectsAdviser, userHasRole } from "@/helpers/roles";
 import { GetProjectResponse, GetUsersResponse, HTTP_METHOD } from "@/types/api";
 import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
 import { ROLES } from "@/types/roles";
+import Switch from "@/components/formikFormControllers/Switch";
 
 type EditProjectFormValues = Pick<
   Project,
-  "name" | "achievement" | "proposalPdf"
+  "name" | "achievement" | "proposalPdf" | "hasDropped"
 > & { students: number[]; adviser: number | ""; mentor: number | "" };
 
 const EditProject: NextPage = () => {
@@ -60,6 +61,7 @@ const EditProject: NextPage = () => {
       : [],
     adviser: project?.adviser?.adviserId ?? "",
     mentor: project?.mentor?.mentorId ?? "",
+    hasDropped: project?.hasDropped ?? false,
   };
 
   /** Fetching student, adviser and mentor IDs and names for the dropdown select */
@@ -109,8 +111,7 @@ const EditProject: NextPage = () => {
         >
           <UnauthorizedWrapper
             isUnauthorized={
-              !user ||
-              !userHasRole(user, ROLES.ADMINISTRATORS) ||
+              !userHasRole(user, ROLES.ADMINISTRATORS) &&
               !checkIfProjectsAdviser(projectResponse?.project, user)
             }
           >
@@ -125,8 +126,7 @@ const EditProject: NextPage = () => {
                     {(formik) => (
                       <form onSubmit={formik.handleSubmit}>
                         <Stack direction="column" spacing="1rem">
-                          {(!user ||
-                            !userHasRole(user, ROLES.ADMINISTRATORS)) && (
+                          {!userHasRole(user, ROLES.ADMINISTRATORS) && (
                             <Alert color="warning" icon={<></>}>
                               You do not have the permissions to edit some of
                               the team&apos;s details
@@ -147,7 +147,7 @@ const EditProject: NextPage = () => {
                               }
                             )}
                             isDisabled={
-                              !user || !userHasRole(user, ROLES.ADMINISTRATORS)
+                              !userHasRole(user, ROLES.ADMINISTRATORS)
                             }
                           />
                           <MultiDropdown
@@ -166,7 +166,7 @@ const EditProject: NextPage = () => {
                                 : []
                             }
                             isDisabled={
-                              !user || !userHasRole(user, ROLES.ADMINISTRATORS)
+                              !userHasRole(user, ROLES.ADMINISTRATORS)
                             }
                           />
                           <Dropdown
@@ -185,7 +185,7 @@ const EditProject: NextPage = () => {
                                 : []
                             }
                             isDisabled={
-                              !user || !userHasRole(user, ROLES.ADMINISTRATORS)
+                              !userHasRole(user, ROLES.ADMINISTRATORS)
                             }
                           />
                           <Dropdown
@@ -204,13 +204,21 @@ const EditProject: NextPage = () => {
                                 : []
                             }
                             isDisabled={
-                              !user || !userHasRole(user, ROLES.ADMINISTRATORS)
+                              !userHasRole(user, ROLES.ADMINISTRATORS)
                             }
                           />
                           <TextInput
                             name="proposalPdf"
                             label="Proposal PDF"
                             formik={formik}
+                          />
+                          <Switch
+                            name="hasDropped"
+                            label="Has Dropped"
+                            formik={formik}
+                            isDisabled={
+                              !userHasRole(user, ROLES.ADMINISTRATORS)
+                            }
                           />
 
                           <Stack direction="row" justifyContent="end">

--- a/pages/projects/[projectId]/index.tsx
+++ b/pages/projects/[projectId]/index.tsx
@@ -64,7 +64,7 @@ const ProjectDetails: NextPage = () => {
           <Box
             component="img"
             src={"https://nusskylab-dev.comp.nus.edu.sg/posters/2021/2680.jpg"}
-            alt={`${project?.name} Project`}
+            alt={`${project?.teamName} Project`}
             sx={{
               objectFit: "cover",
               height: "50vw",
@@ -107,7 +107,7 @@ const ProjectDetails: NextPage = () => {
                 textAlign="center"
                 mb="1.5rem"
               >
-                {`${project?.name}`}
+                {`${project?.teamName}`}
               </Typography>
               {project && (
                 <Stack spacing="0.5rem">

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -66,6 +66,7 @@ const Projects: NextPage = () => {
       achievement: selectedLevel,
       search: querySearch,
       limit: LIMIT,
+      dropped: false,
     };
   }, [selectedCohortYear, selectedLevel, querySearch]);
   const {

--- a/types/projects.ts
+++ b/types/projects.ts
@@ -21,6 +21,7 @@ export enum LEVELS_OF_ACHIEVEMENT_WITH_ALL {
 export type Project = {
   id: number;
   name: string;
+  teamName: string;
   proposalPdf: string;
   students: Student[];
   adviser?: Adviser;

--- a/types/projects.ts
+++ b/types/projects.ts
@@ -27,6 +27,7 @@ export type Project = {
   mentor?: Mentor;
   achievement: LEVELS_OF_ACHIEVEMENT;
   cohortYear: Cohort["academicYear"];
+  hasDropped: boolean;
 };
 
 export type LeanProject = Pick<Project, "id" | "name">;


### PR DESCRIPTION
- [x] Add `hasDropped` attribute to project type
- [x] Add has dropped switch on manage projects page
- [x] Add has dropped switch on editing projects page
- [x] Add `teamName` attribute to project type
- [x] Update cards and displays to use team name instead of name

Depends on BE PR to:
1. Add `hasDropped` field to schema (defaults to false)
2. Add `hasDropped` query param to `/api/projects` route accordingly
3. Add `teamName` field to schema