### PR TITLE
feat: add required field for Question

### DIFF
--- a/components/questions/QuestionCard/CheckboxesQuestion/CheckboxesQuestion.tsx
+++ b/components/questions/QuestionCard/CheckboxesQuestion/CheckboxesQuestion.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   FormGroup,
   Stack,
   Typography,
@@ -17,6 +18,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const CheckboxesQuestion: FC<Props> = ({
@@ -24,6 +27,8 @@ const CheckboxesQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const isChecked = (option: string) => {
     try {
@@ -49,6 +54,9 @@ const CheckboxesQuestion: FC<Props> = ({
         answerObject[option] = true;
       }
       setAnswer(JSON.stringify(answerObject));
+      if (hasError && onClearError) {
+        onClearError();
+      }
     };
     return toggleCheck;
   };
@@ -60,7 +68,17 @@ const CheckboxesQuestion: FC<Props> = ({
       sx={{ width: "100%" }}
     >
       <QuestionAndDesc question={question} questionType="Checkboxes" />
-      <FormControl>
+      <FormControl
+        error={hasError}
+        sx={{
+          width: "100%",
+          border: hasError ? "1px solid" : "1px solid transparent",
+          borderColor: hasError ? "error.main" : "transparent",
+          borderRadius: "4px",
+          padding: hasError ? "0.5rem" : "0.5rem",
+          marginLeft: "-0.5rem",
+        }}
+      >
         <FormGroup>
           {question.options ? (
             <>
@@ -83,6 +101,7 @@ const CheckboxesQuestion: FC<Props> = ({
             <Typography>No options were provided</Typography>
           )}
         </FormGroup>
+        {hasError && <FormHelperText>This field is required</FormHelperText>}
       </FormControl>
     </Stack>
   );

--- a/components/questions/QuestionCard/CheckboxesQuestion/CheckboxesQuestion.tsx
+++ b/components/questions/QuestionCard/CheckboxesQuestion/CheckboxesQuestion.tsx
@@ -75,7 +75,7 @@ const CheckboxesQuestion: FC<Props> = ({
           border: hasError ? "1px solid" : "1px solid transparent",
           borderColor: hasError ? "error.main" : "transparent",
           borderRadius: "4px",
-          padding: hasError ? "0.5rem" : "0.5rem",
+          padding: "0.5rem",
           marginLeft: "-0.5rem",
         }}
       >

--- a/components/questions/QuestionCard/DateQuestion/DateQuestion.tsx
+++ b/components/questions/QuestionCard/DateQuestion/DateQuestion.tsx
@@ -10,6 +10,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const DateQuestion: FC<Props> = ({
@@ -17,9 +19,14 @@ const DateQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
@@ -34,6 +41,8 @@ const DateQuestion: FC<Props> = ({
         inputProps={{
           readOnly: isReadonly,
         }}
+        error={hasError}
+        helperText={hasError && "This field is required"}
       />
     </Stack>
   );

--- a/components/questions/QuestionCard/DropdownQuestion/DropdownQuestion.tsx
+++ b/components/questions/QuestionCard/DropdownQuestion/DropdownQuestion.tsx
@@ -10,6 +10,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const DropdownQuestion: FC<Props> = ({
@@ -17,9 +19,14 @@ const DropdownQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
@@ -35,6 +42,8 @@ const DropdownQuestion: FC<Props> = ({
         onChange={handleChange}
         select
         inputProps={{ readOnly: isReadonly }}
+        error={hasError}
+        helperText={hasError && "This field is required"}
       >
         {question.options &&
           question.options.map((option, idx) => (

--- a/components/questions/QuestionCard/EditQuestionConfig/EditQuestionConfig.tsx
+++ b/components/questions/QuestionCard/EditQuestionConfig/EditQuestionConfig.tsx
@@ -73,6 +73,7 @@ const EditQuestionConfig: FC<Props> = ({ question, setQuestion }) => {
           <FormControlLabel
             value={question.isAnonymous}
             onClick={handleToggleAnonymous}
+            checked={question.isAnonymous}
             control={<Switch color="secondary" size="small" />}
             label="Anonymous"
             labelPlacement="start"
@@ -85,6 +86,7 @@ const EditQuestionConfig: FC<Props> = ({ question, setQuestion }) => {
           <FormControlLabel
             value={question.isRequired}
             onClick={handleToggleRequired}
+            checked={question.isRequired}
             control={<Switch color="secondary" size="small" />}
             label="Required"
             labelPlacement="start"

--- a/components/questions/QuestionCard/EditQuestionConfig/EditQuestionConfig.tsx
+++ b/components/questions/QuestionCard/EditQuestionConfig/EditQuestionConfig.tsx
@@ -33,6 +33,12 @@ const EditQuestionConfig: FC<Props> = ({ question, setQuestion }) => {
     setQuestion(newQuestion);
   };
 
+  const handleToggleRequired = () => {
+    const newQuestion: LeanQuestion = { ...question };
+    newQuestion.isRequired = !question.isRequired;
+    setQuestion(newQuestion);
+  };
+
   const handleDeleteQuestion = () => {
     setQuestion();
   };
@@ -69,6 +75,18 @@ const EditQuestionConfig: FC<Props> = ({ question, setQuestion }) => {
             onClick={handleToggleAnonymous}
             control={<Switch color="secondary" size="small" />}
             label="Anonymous"
+            labelPlacement="start"
+          />
+        </Tooltip>
+        <Tooltip
+          title="A required question means that the receiver of the question must answer this question before submitting"
+          placement="top"
+        >
+          <FormControlLabel
+            value={question.isRequired}
+            onClick={handleToggleRequired}
+            control={<Switch color="secondary" size="small" />}
+            label="Required"
             labelPlacement="start"
           />
         </Tooltip>

--- a/components/questions/QuestionCard/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
+++ b/components/questions/QuestionCard/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, FC } from "react";
 import {
   FormControl,
   FormControlLabel,
+  FormHelperText,
   Radio,
   RadioGroup,
   Stack,
@@ -17,6 +18,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const MultipleChoiceQuestion: FC<Props> = ({
@@ -24,15 +27,30 @@ const MultipleChoiceQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
     <Stack className="mcq-question" spacing="0.5rem" sx={{ width: "100%" }}>
       <QuestionAndDesc question={question} questionType="Multiple Choice" />
-      <FormControl>
+      <FormControl
+        error={hasError}
+        sx={{
+          width: "100%",
+          border: hasError ? "1px solid" : "1px solid transparent",
+          borderColor: hasError ? "error.main" : "transparent",
+          borderRadius: "4px",
+          padding: hasError ? "0.5rem" : "0.5rem",
+          marginLeft: "-0.5rem",
+        }}
+      >
         <RadioGroup value={answer} onChange={handleChange}>
           {question.options ? (
             <>
@@ -55,6 +73,7 @@ const MultipleChoiceQuestion: FC<Props> = ({
             <Typography>No options were provided</Typography>
           )}
         </RadioGroup>
+        {hasError && <FormHelperText>This field is required</FormHelperText>}
       </FormControl>
     </Stack>
   );

--- a/components/questions/QuestionCard/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
+++ b/components/questions/QuestionCard/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
@@ -47,7 +47,7 @@ const MultipleChoiceQuestion: FC<Props> = ({
           border: hasError ? "1px solid" : "1px solid transparent",
           borderColor: hasError ? "error.main" : "transparent",
           borderRadius: "4px",
-          padding: hasError ? "0.5rem" : "0.5rem",
+          padding: "0.5rem",
           marginLeft: "-0.5rem",
         }}
       >

--- a/components/questions/QuestionCard/ParagraphQuestion/ParagraphQuestion.tsx
+++ b/components/questions/QuestionCard/ParagraphQuestion/ParagraphQuestion.tsx
@@ -10,6 +10,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const ParagraphQuestion: FC<Props> = ({
@@ -17,9 +19,14 @@ const ParagraphQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
@@ -40,6 +47,8 @@ const ParagraphQuestion: FC<Props> = ({
         inputProps={{
           readOnly: isReadonly,
         }}
+        error={hasError}
+        helperText={hasError && "This field is required"}
       />
     </Stack>
   );

--- a/components/questions/QuestionCard/QuestionAndDesc/QuestionAndDesc.tsx
+++ b/components/questions/QuestionCard/QuestionAndDesc/QuestionAndDesc.tsx
@@ -2,6 +2,7 @@ import { LeanQuestion, Question } from "@/types/deadlines";
 import { Stack, Typography } from "@mui/material";
 import { FC } from "react";
 import AnonymousChip from "../AnonymousChip";
+import RequiredChip from "../RequiredChip";
 
 type Props = {
   question: LeanQuestion | Question;
@@ -18,6 +19,7 @@ const QuestionAndDesc: FC<Props> = ({ question, questionType }) => {
             : `<Empty ${questionType} Question> (Will not be saved if a question is not provided)`}
         </Typography>
         {question.isAnonymous && <AnonymousChip />}
+        {question.isRequired && <RequiredChip />}
       </Stack>
       {question.desc && (
         <Typography

--- a/components/questions/QuestionCard/QuestionCard.tsx
+++ b/components/questions/QuestionCard/QuestionCard.tsx
@@ -32,6 +32,8 @@ type Props = {
   answer?: Option; // Only valid when isEditMode === false
   setAnswer?: (newAnswer: string) => void;
   isReadonly?: boolean; // Only valid when isEditMode === false
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 /**
@@ -48,6 +50,8 @@ const QuestionCard: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const getQuestionNumber = () => {
     if (isQuestion(question)) {
@@ -120,6 +124,8 @@ const QuestionCard: FC<Props> = ({
         answer,
         setAnswer,
         isReadonly: Boolean(isReadonly),
+        hasError,
+        onClearError,
       };
       switch (question.type) {
         case QUESTION_TYPE.SHORT_ANSWER:

--- a/components/questions/QuestionCard/RequiredChip/RequiredChip.tsx
+++ b/components/questions/QuestionCard/RequiredChip/RequiredChip.tsx
@@ -1,0 +1,18 @@
+import { PriorityHigh } from "@mui/icons-material";
+import { Chip, Tooltip } from "@mui/material";
+import { FC } from "react";
+
+const RequiredChip: FC = () => {
+  return (
+    <Tooltip title="This question is required, meaning the receiver must answer it before submitting.">
+      <Chip
+        icon={<PriorityHigh />}
+        label="Required"
+        size="small"
+        color="primary"
+        variant="outlined"
+      />
+    </Tooltip>
+  );
+};
+export default RequiredChip;

--- a/components/questions/QuestionCard/RequiredChip/index.tsx
+++ b/components/questions/QuestionCard/RequiredChip/index.tsx
@@ -1,0 +1,2 @@
+import RequiredChip from "./RequiredChip";
+export default RequiredChip;

--- a/components/questions/QuestionCard/RichTextEditorQuestion/RichTextEditorQuestion.tsx
+++ b/components/questions/QuestionCard/RichTextEditorQuestion/RichTextEditorQuestion.tsx
@@ -1,5 +1,5 @@
 import { LeanQuestion, Question, Option } from "@/types/deadlines";
-import { Stack } from "@mui/material";
+import { Box, FormHelperText, Stack } from "@mui/material";
 import React, { FC } from "react";
 import QuestionAndDesc from "../QuestionAndDesc";
 import RichTextEditor from "@/components/formikFormControllers/RichTextEditor";
@@ -9,16 +9,30 @@ type Props = {
   question: LeanQuestion | Question;
   setAnswer: (newAnswer: string) => void;
   answer: Option;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 type RichTextEditorQuestionFormValues = {
   answer: Option;
 };
 
-const RichTextEditorQuestion: FC<Props> = ({ question, answer, setAnswer }) => {
+const RichTextEditorQuestion: FC<Props> = ({
+  question,
+  answer,
+  setAnswer,
+  hasError = false,
+  onClearError,
+}) => {
   const initialValues: RichTextEditorQuestionFormValues = { answer };
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const handleSubmit = () => {};
+  const handleEditorChange = (content: string) => {
+    setAnswer(content);
+    if (hasError && onClearError) {
+      onClearError();
+    }
+  };
 
   return (
     <Formik onSubmit={handleSubmit} initialValues={initialValues}>
@@ -29,11 +43,32 @@ const RichTextEditorQuestion: FC<Props> = ({ question, answer, setAnswer }) => {
           sx={{ width: "100%" }}
         >
           <QuestionAndDesc question={question} questionType="RichTextEditor" />
-          <RichTextEditor
-            name="answer"
-            formik={formik}
-            handleChange={setAnswer}
-          />
+          <Box
+            sx={{
+              border: hasError ? "1px solid" : "1px solid transparent",
+              borderColor: hasError ? "error.main" : "transparent",
+              borderRadius: "4px",
+              padding: "2px",
+              width: "100%",
+              "& .MuiFormControl-root": {
+                width: "100%",
+              },
+            }}
+          >
+            <RichTextEditor
+              name="answer"
+              formik={formik}
+              handleChange={handleEditorChange}
+            />
+          </Box>
+          {hasError && (
+            <FormHelperText
+              error
+              sx={{ marginLeft: "14px", marginTop: "-4px" }}
+            >
+              This field is required
+            </FormHelperText>
+          )}
         </Stack>
       )}
     </Formik>

--- a/components/questions/QuestionCard/ShortAnswerQuestion/ShortAnswerQuestion.tsx
+++ b/components/questions/QuestionCard/ShortAnswerQuestion/ShortAnswerQuestion.tsx
@@ -10,6 +10,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const ShortAnswerQuestion: FC<Props> = ({
@@ -17,9 +19,14 @@ const ShortAnswerQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
@@ -38,6 +45,8 @@ const ShortAnswerQuestion: FC<Props> = ({
         inputProps={{
           readOnly: isReadonly,
         }}
+        error={hasError}
+        helperText={hasError && "This field is required"}
       />
     </Stack>
   );

--- a/components/questions/QuestionCard/TimeQuestion/TimeQuestion.tsx
+++ b/components/questions/QuestionCard/TimeQuestion/TimeQuestion.tsx
@@ -10,6 +10,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const TimeQuestion: FC<Props> = ({
@@ -17,9 +19,14 @@ const TimeQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
   return (
@@ -34,6 +41,8 @@ const TimeQuestion: FC<Props> = ({
         inputProps={{
           readOnly: isReadonly,
         }}
+        error={hasError}
+        helperText={hasError && "This field is required"}
       />
     </Stack>
   );

--- a/components/questions/QuestionCard/UrlQuestion/UrlQuestion.tsx
+++ b/components/questions/QuestionCard/UrlQuestion/UrlQuestion.tsx
@@ -11,6 +11,8 @@ type Props = {
   answer: Option;
   setAnswer: (newAnswer: string) => void;
   isReadonly: boolean;
+  hasError?: boolean;
+  onClearError?: () => void;
 };
 
 const UrlQuestion: FC<Props> = ({
@@ -18,6 +20,8 @@ const UrlQuestion: FC<Props> = ({
   answer,
   setAnswer,
   isReadonly,
+  hasError = false,
+  onClearError,
 }) => {
   const [touched, setTouched] = useState(false);
 
@@ -26,9 +30,13 @@ const UrlQuestion: FC<Props> = ({
       setTouched(true);
     }
     setAnswer(e.target.value);
+    if (hasError && onClearError) {
+      onClearError();
+    }
   };
 
-  const isInvalid = touched && !validateUrl(answer);
+  const isUrlFormatInvalid = touched && !validateUrl(answer);
+  const showRedBorder = isUrlFormatInvalid || hasError;
 
   return (
     <Stack className="url-question" spacing="0.5rem" sx={{ width: "100%" }}>
@@ -42,8 +50,11 @@ const UrlQuestion: FC<Props> = ({
             size="small"
             type="url"
             placeholder="Your URL here"
-            error={isInvalid}
-            helperText={isInvalid && "Please enter a valid URL"}
+            error={showRedBorder}
+            helperText={
+              (isUrlFormatInvalid && "Please enter a valid URL") ||
+              (hasError && "This field is required")
+            }
           />
         </>
       ) : (

--- a/components/questions/QuestionCard/UrlQuestion/UrlQuestion.tsx
+++ b/components/questions/QuestionCard/UrlQuestion/UrlQuestion.tsx
@@ -52,8 +52,8 @@ const UrlQuestion: FC<Props> = ({
             placeholder="Your URL here"
             error={showRedBorder}
             helperText={
-              (isUrlFormatInvalid && "Please enter a valid URL") ||
-              (hasError && "This field is required")
+              (hasError && "This field is required") ||
+              (isUrlFormatInvalid && "Please enter a valid URL")
             }
           />
         </>

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -4,12 +4,13 @@ import QuestionsList from "./QuestionsList";
 import { Card, CardContent, Stack, Typography } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 // Helpers
-import { isSection } from "@/helpers/types";
+import { isSection, isQuestion } from "@/helpers/types";
 import { generateIndexOffset } from "@/hooks/useAnswers/useAnswers.helpers";
 // Types
 import { UseAnswersActions } from "@/hooks/useAnswers";
-import { LeanSection, Section } from "@/types/deadlines";
+import { LeanSection, QUESTION_TYPE, Section } from "@/types/deadlines";
 import { Answer } from "@/types/submissions";
+import useSnackbarAlert from "@/contexts/useSnackbarAlert";
 
 type Props = {
   questionSections: (Section | LeanSection)[];
@@ -39,6 +40,7 @@ const QuestionSectionsList: FC<Props> = ({
   isDraft = true,
   includeAnonymousQuestions = false,
 }) => {
+  const { setError } = useSnackbarAlert();
   const getSectionNumber = (section: Section | LeanSection, idx: number) => {
     if (isSection(section)) {
       return section.sectionNumber;
@@ -47,6 +49,75 @@ const QuestionSectionsList: FC<Props> = ({
     } else {
       return -1;
     }
+  };
+
+  const handleValidationAndSubmit = () => {
+    if (!submitAnswers) return;
+
+    const allQuestions = questionSections.flatMap(
+      (section) => section.questions
+    );
+
+    const firstMissingQuestion = allQuestions.find((question, index) => {
+      if (!question.isRequired) return false;
+
+      if (question.isAnonymous && !includeAnonymousQuestions) return false;
+
+      let answer: string | undefined;
+
+      if (accessAnswersWithQuestionIndex) {
+        answer = answers.get(index);
+      } else {
+        if (isQuestion(question)) {
+          answer = answers.get(question.id);
+        } else {
+          // Cannot validate LeanQuestion without index mode
+          return false;
+        }
+      }
+
+      if (answer === undefined || answer === null) return true;
+
+      switch (question.type) {
+        case QUESTION_TYPE.CHECKBOXES:
+          try {
+            const answerObj = JSON.parse(answer);
+            const hasCheckedOption = Object.values(answerObj).some(
+              (val) => val === true
+            );
+            return !hasCheckedOption;
+          } catch (e) {
+            return true;
+          }
+
+        case QUESTION_TYPE.RICH_TEXT_EDITOR: {
+          const strippedContent = answer.replace(/<[^>]*>/g, "").trim();
+          return strippedContent === "";
+        }
+
+        case QUESTION_TYPE.SHORT_ANSWER:
+        case QUESTION_TYPE.PARAGRAPH:
+        case QUESTION_TYPE.URL:
+        case QUESTION_TYPE.DROPDOWN:
+        case QUESTION_TYPE.MULTIPLE_CHOICE:
+        case QUESTION_TYPE.DATE:
+        case QUESTION_TYPE.TIME:
+        default:
+          return answer.trim() === "";
+      }
+    });
+
+    if (firstMissingQuestion) {
+      setError(
+        `Please fill in the required question: "${firstMissingQuestion.question}"`
+      );
+      return;
+    }
+
+    submitAnswers({
+      isDraft: false,
+      shouldDisplaySuccess: true,
+    });
   };
 
   return (
@@ -149,15 +220,7 @@ const QuestionSectionsList: FC<Props> = ({
           <LoadingButton
             id="submit-submission-button"
             variant="contained"
-            onClick={
-              submitAnswers
-                ? () =>
-                    submitAnswers({
-                      isDraft: false,
-                      shouldDisplaySuccess: true,
-                    })
-                : undefined
-            }
+            onClick={handleValidationAndSubmit}
             loading={isSubmitting}
             disabled={isSubmitting}
           >

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -142,7 +142,6 @@ const QuestionSectionsList: FC<Props> = ({
           `Please fill in: ${firstFewNames} and ${remainingCount} others.`
         );
       }
-      document.getElementById("question-section-list-div")?.scrollIntoView();
       return;
     }
 

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -88,7 +88,7 @@ const QuestionSectionsList: FC<Props> = ({
         (q) => q.isRequired && (!q.isAnonymous || includeAnonymousQuestions)
       );
 
-    const firstMissingQuestion = requiredQuestions.find((question, index) => {
+    const missingQuestions = requiredQuestions.filter((question, index) => {
       const key = accessAnswersWithQuestionIndex
         ? index
         : isQuestion(question)
@@ -101,8 +101,20 @@ const QuestionSectionsList: FC<Props> = ({
       return isAnswerEmpty(question, answer);
     });
 
-    if (firstMissingQuestion) {
-      setError(`Please fill in: "${firstMissingQuestion.question}"`);
+    if (missingQuestions.length > 0) {
+      const firstFewNames = missingQuestions
+        .slice(0, 3)
+        .map((q) => `"${q.question}"`)
+        .join(", ");
+      if (missingQuestions.length <= 3) {
+        setError(`Please fill in: ${firstFewNames}`);
+      } else {
+        const remainingCount = missingQuestions.length - 3;
+        setError(
+          `Please fill in: ${firstFewNames} and ${remainingCount} others.`
+        );
+      }
+      document.getElementById("question-section-list-div")?.scrollIntoView();
       return;
     }
 

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -8,7 +8,13 @@ import { isSection, isQuestion } from "@/helpers/types";
 import { generateIndexOffset } from "@/hooks/useAnswers/useAnswers.helpers";
 // Types
 import { UseAnswersActions } from "@/hooks/useAnswers";
-import { LeanSection, QUESTION_TYPE, Section } from "@/types/deadlines";
+import {
+  LeanQuestion,
+  LeanSection,
+  Question,
+  QUESTION_TYPE,
+  Section,
+} from "@/types/deadlines";
 import { Answer } from "@/types/submissions";
 import useSnackbarAlert from "@/contexts/useSnackbarAlert";
 
@@ -51,73 +57,56 @@ const QuestionSectionsList: FC<Props> = ({
     }
   };
 
+  const isAnswerEmpty = (
+    question: LeanQuestion | Question,
+    answer: string | undefined
+  ): boolean => {
+    if (answer === undefined || answer === null) return true;
+
+    switch (question.type) {
+      case QUESTION_TYPE.CHECKBOXES:
+        try {
+          const answerObj =
+            typeof answer === "string" ? JSON.parse(answer) : answer;
+          return !Object.values(answerObj).some((val) => val === true);
+        } catch {
+          return true;
+        }
+      case QUESTION_TYPE.RICH_TEXT_EDITOR:
+        return answer.replace(/<[^>]*>/g, "").trim() === "";
+      default:
+        return String(answer).trim() === "";
+    }
+  };
+
   const handleValidationAndSubmit = () => {
     if (!submitAnswers) return;
 
-    const allQuestions = questionSections.flatMap(
-      (section) => section.questions
-    );
+    const requiredQuestions = questionSections
+      .flatMap((section) => section.questions)
+      .filter(
+        (q) => q.isRequired && (!q.isAnonymous || includeAnonymousQuestions)
+      );
 
-    const firstMissingQuestion = allQuestions.find((question, index) => {
-      if (!question.isRequired) return false;
+    const firstMissingQuestion = requiredQuestions.find((question, index) => {
+      const key = accessAnswersWithQuestionIndex
+        ? index
+        : isQuestion(question)
+        ? question.id
+        : null;
 
-      if (question.isAnonymous && !includeAnonymousQuestions) return false;
+      if (key === null) return false;
 
-      let answer: string | undefined;
-
-      if (accessAnswersWithQuestionIndex) {
-        answer = answers.get(index);
-      } else {
-        if (isQuestion(question)) {
-          answer = answers.get(question.id);
-        } else {
-          // Cannot validate LeanQuestion without index mode
-          return false;
-        }
-      }
-
-      if (answer === undefined || answer === null) return true;
-
-      switch (question.type) {
-        case QUESTION_TYPE.CHECKBOXES:
-          try {
-            const answerObj = JSON.parse(answer);
-            const hasCheckedOption = Object.values(answerObj).some(
-              (val) => val === true
-            );
-            return !hasCheckedOption;
-          } catch (e) {
-            return true;
-          }
-
-        case QUESTION_TYPE.RICH_TEXT_EDITOR: {
-          const strippedContent = answer.replace(/<[^>]*>/g, "").trim();
-          return strippedContent === "";
-        }
-
-        case QUESTION_TYPE.SHORT_ANSWER:
-        case QUESTION_TYPE.PARAGRAPH:
-        case QUESTION_TYPE.URL:
-        case QUESTION_TYPE.DROPDOWN:
-        case QUESTION_TYPE.MULTIPLE_CHOICE:
-        case QUESTION_TYPE.DATE:
-        case QUESTION_TYPE.TIME:
-        default:
-          return answer.trim() === "";
-      }
+      const answer = answers.get(key);
+      return isAnswerEmpty(question, answer);
     });
 
     if (firstMissingQuestion) {
-      setError(
-        `Please fill in the required question: "${firstMissingQuestion.question}"`
-      );
+      setError(`Please fill in: "${firstMissingQuestion.question}"`);
       return;
     }
 
-    submitAnswers({
-      isDraft: false,
-      shouldDisplaySuccess: true,
-    });
+    submitAnswers({ isDraft: false, shouldDisplaySuccess: true });
   };
 
   return (

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -97,6 +97,24 @@ const QuestionSectionsList: FC<Props> = ({
     }
   };
 
+  /**
+   * Get the label to display for a question, falling back to question type or a default if question text is not available.
+   *
+   * @param q The question to get the label for.
+   * @returns The label to display for the question.
+   */
+  const getQuestionLabel = (q: LeanQuestion | Question) => {
+    if (typeof q.question === "string" && q.question.trim().length > 0) {
+      return q.question;
+    }
+
+    if (isQuestion(q) && q.type) {
+      return q.type;
+    }
+
+    return "Untitled question";
+  };
+
   const handleValidationAndSubmit = () => {
     if (!submitAnswers) return;
 
@@ -132,7 +150,7 @@ const QuestionSectionsList: FC<Props> = ({
 
       const firstFewNames = missingQuestions
         .slice(0, 3)
-        .map((q) => `"${q.question}"`)
+        .map((q) => `"${getQuestionLabel(q)}"`)
         .join(", ");
       if (missingQuestions.length <= 3) {
         setError(`Please fill in: ${firstFewNames}`);

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 // Components
 import QuestionsList from "./QuestionsList";
 import { Card, CardContent, Stack, Typography } from "@mui/material";
@@ -47,6 +47,24 @@ const QuestionSectionsList: FC<Props> = ({
   includeAnonymousQuestions = false,
 }) => {
   const { setError } = useSnackbarAlert();
+  const [questionErrors, setQuestionErrors] = useState<Record<string, boolean>>(
+    {}
+  );
+
+  /**
+   * Clear error for a question
+   * @param questionId ID of the question to clear error for
+   */
+  const handleClearError = (questionId: number) => {
+    if (questionErrors[questionId]) {
+      setQuestionErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors[questionId];
+        return newErrors;
+      });
+    }
+  };
+
   const getSectionNumber = (section: Section | LeanSection, idx: number) => {
     if (isSection(section)) {
       return section.sectionNumber;
@@ -82,6 +100,8 @@ const QuestionSectionsList: FC<Props> = ({
   const handleValidationAndSubmit = () => {
     if (!submitAnswers) return;
 
+    setQuestionErrors({});
+
     const requiredQuestions = questionSections
       .flatMap((section) => section.questions)
       .filter(
@@ -102,6 +122,14 @@ const QuestionSectionsList: FC<Props> = ({
     });
 
     if (missingQuestions.length > 0) {
+      const newErrors: Record<string, boolean> = {};
+      missingQuestions.forEach((q) => {
+        if (isQuestion(q)) {
+          newErrors[q.id] = true;
+        }
+      });
+      setQuestionErrors(newErrors);
+
       const firstFewNames = missingQuestions
         .slice(0, 3)
         .map((q) => `"${q.question}"`)
@@ -188,6 +216,8 @@ const QuestionSectionsList: FC<Props> = ({
                 accessAnswersWithQuestionIndex={accessAnswersWithQuestionIndex}
                 indexOffset={indexOffset}
                 isReadonly={Boolean(isReadonly)}
+                errors={questionErrors}
+                onClearError={handleClearError}
               />
             </CardContent>
           </Card>

--- a/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionSectionsList.tsx
@@ -120,42 +120,54 @@ const QuestionSectionsList: FC<Props> = ({
 
     setQuestionErrors({});
 
-    const requiredQuestions = questionSections
-      .flatMap((section) => section.questions)
-      .filter(
-        (q) => q.isRequired && (!q.isAnonymous || includeAnonymousQuestions)
-      );
+    const questionsWithKeys = questionSections.flatMap(
+      (section, sectionIdx) => {
+        const indexOffset = accessAnswersWithQuestionIndex
+          ? generateIndexOffset(questionSections, sectionIdx)
+          : 0;
 
-    const missingQuestions = requiredQuestions.filter((question, index) => {
-      const key = accessAnswersWithQuestionIndex
-        ? index
-        : isQuestion(question)
-        ? question.id
-        : null;
+        return section.questions.map((q, qIdx) => {
+          const key = accessAnswersWithQuestionIndex
+            ? indexOffset + qIdx
+            : isQuestion(q)
+            ? q.id
+            : null;
 
+          return { question: q, key };
+        });
+      }
+    );
+
+    const requiredQuestions = questionsWithKeys.filter(
+      ({ question: q }) =>
+        q.isRequired && (!q.isAnonymous || includeAnonymousQuestions)
+    );
+
+    const missingItems = requiredQuestions.filter(({ question, key }) => {
       if (key === null) return false;
 
       const answer = answers.get(key);
       return isAnswerEmpty(question, answer);
     });
 
-    if (missingQuestions.length > 0) {
+    if (missingItems.length > 0) {
       const newErrors: Record<string, boolean> = {};
-      missingQuestions.forEach((q) => {
-        if (isQuestion(q)) {
-          newErrors[q.id] = true;
+      missingItems.forEach(({ key }) => {
+        if (key !== null) {
+          newErrors[key] = true;
         }
       });
       setQuestionErrors(newErrors);
 
-      const firstFewNames = missingQuestions
+      const firstFewNames = missingItems
         .slice(0, 3)
-        .map((q) => `"${getQuestionLabel(q)}"`)
+        .map(({ question }) => `"${getQuestionLabel(question)}"`)
         .join(", ");
-      if (missingQuestions.length <= 3) {
+
+      if (missingItems.length <= 3) {
         setError(`Please fill in: ${firstFewNames}`);
       } else {
-        const remainingCount = missingQuestions.length - 3;
+        const remainingCount = missingItems.length - 3;
         setError(
           `Please fill in: ${firstFewNames} and ${remainingCount} others.`
         );

--- a/components/questions/QuestionSectionsList/QuestionsList/QuestionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionsList/QuestionsList.tsx
@@ -17,6 +17,40 @@ type Props = {
 };
 
 /**
+ * Get the question identifier based on the `accessAnswersWithQuestionIndex` flag. If the flag is false, the identifier is the question ID; if true, the identifier is the question index (offset by `indexOffset` if provided).
+ * @param question The question object
+ * @param idx The index of the question in the list
+ * @param accessByIndex Whether to access answers by index instead of question ID
+ * @param offset The offset to apply to the index if accessing by index
+ * @returns The question identifier (either question ID or index) or null if there's an error in configuration
+ */
+const getQuestionIdentifier = (
+  question: Question | LeanQuestion,
+  idx: number,
+  accessByIndex: boolean,
+  offset?: number
+): number | null => {
+  if (!accessByIndex) {
+    if (!isQuestion(question)) {
+      console.error(
+        "`accessAnswersWithQuestionIndex` cannot be false if questions lack an ID."
+      );
+      return null;
+    }
+    return question.id;
+  }
+
+  if (offset === undefined) {
+    console.error(
+      "`accessAnswersWithQuestionIndex` is enabled, but `indexOffset` is undefined."
+    );
+    return null;
+  }
+
+  return offset + idx;
+};
+
+/**
  * Render a list of questions that users can interact with (i.e. can input answers)
  * @param param0.questions List of questions to render
  * @param param0.answers Object of answers where key is (question ID OR question index) and value is the answer to the question.
@@ -45,33 +79,24 @@ const QuestionsList: FC<Props> = ({
          * Else it is stored and accessed via its questionId.
          * (The index is offset as )
          */
-        let questionIdOrIdx: number;
-        if (!accessAnswersWithQuestionIndex) {
-          if (isQuestion(question)) {
-            questionIdOrIdx = question.id;
-          } else {
-            return alert(
-              "You should not enable the `accessAnswersWithQuestionIndex` flag if the questions do not have an ID. (i.e. edit deadline questions page)"
-            );
-          }
-        } else {
-          if (indexOffset !== undefined) {
-            questionIdOrIdx = indexOffset + idx;
-          } else {
-            return alert(
-              "You should not enable the `accessAnswersWithQuestionIndex` flag without providing the indexOffset"
-            );
-          }
+        const questionIdOrIdx = getQuestionIdentifier(
+          question,
+          idx,
+          accessAnswersWithQuestionIndex,
+          indexOffset
+        );
+
+        if (questionIdOrIdx === null) {
+          return null; // Skip rendering this question due to configuration error
         }
 
         const answer = answers.get(questionIdOrIdx);
         const setAnswer = generateSetAnswer
           ? generateSetAnswer(questionIdOrIdx)
           : undefined;
-
         return (
           <QuestionCard
-            key={idx}
+            key={questionIdOrIdx}
             idx={idx}
             question={question}
             answer={answer}

--- a/components/questions/QuestionSectionsList/QuestionsList/QuestionsList.tsx
+++ b/components/questions/QuestionSectionsList/QuestionsList/QuestionsList.tsx
@@ -12,6 +12,8 @@ type Props = {
   accessAnswersWithQuestionIndex?: boolean;
   indexOffset?: number; // Only valid when `accessAnswersWithQuestionIndex` is true
   isReadonly: boolean;
+  errors?: Record<string, boolean>;
+  onClearError?: (id: number) => void;
 };
 
 /**
@@ -31,6 +33,8 @@ const QuestionsList: FC<Props> = ({
   accessAnswersWithQuestionIndex = false,
   indexOffset,
   isReadonly,
+  errors = {},
+  onClearError,
 }) => {
   return (
     <Stack spacing="1rem">
@@ -41,7 +45,7 @@ const QuestionsList: FC<Props> = ({
          * Else it is stored and accessed via its questionId.
          * (The index is offset as )
          */
-        let questionIdOrIdx;
+        let questionIdOrIdx: number;
         if (!accessAnswersWithQuestionIndex) {
           if (isQuestion(question)) {
             questionIdOrIdx = question.id;
@@ -73,6 +77,8 @@ const QuestionsList: FC<Props> = ({
             answer={answer}
             setAnswer={setAnswer}
             isReadonly={isReadonly}
+            hasError={!!errors[questionIdOrIdx]}
+            onClearError={() => onClearError && onClearError(questionIdOrIdx)}
           />
         );
       })}

--- a/components/tables/AllTeamsMilestoneTable/AllTeamsMilestoneRow/AllTeamsMilestoneRow.tsx
+++ b/components/tables/AllTeamsMilestoneTable/AllTeamsMilestoneRow/AllTeamsMilestoneRow.tsx
@@ -74,7 +74,7 @@ const AllTeamsMilestoneRow: FC<Props> = ({
         );
       }
       case STATUS.SAVED_DRAFT: {
-        return "Saved Draft";
+        return "In Progress";
       }
       case STATUS.SUBMITTED: {
         return (

--- a/components/tables/DeadlineDeliverableTable/DeadlineDeliverableRow/DeadlineDeliverableRow.tsx
+++ b/components/tables/DeadlineDeliverableTable/DeadlineDeliverableRow/DeadlineDeliverableRow.tsx
@@ -151,7 +151,7 @@ const DeadlineDeliverableRow: FC<Props> = ({
         );
       }
       case STATUS.SAVED_DRAFT: {
-        return "Saved Draft";
+        return "In Progress";
       }
       case STATUS.SUBMITTED: {
         return (

--- a/components/tables/SubmissionTable/SubmissionRow/SubmissionRow.tsx
+++ b/components/tables/SubmissionTable/SubmissionRow/SubmissionRow.tsx
@@ -102,7 +102,7 @@ const SubmissionRow: FC<Props> = ({
         );
       }
       case STATUS.SAVED_DRAFT: {
-        return "Saved Draft";
+        return "In Progress";
       }
       case STATUS.SUBMITTED: {
         return (

--- a/hooks/useQuestionSections/useQuestionSections.helpers.ts
+++ b/hooks/useQuestionSections/useQuestionSections.helpers.ts
@@ -171,6 +171,7 @@ const getNewDefaultQuestion = () => {
     type: QUESTION_TYPE.MULTIPLE_CHOICE,
     options: ["Option 1"],
     isAnonymous: false,
+    isRequired: false,
   };
   return newDefaultQuestion;
 };

--- a/types/deadlines.ts
+++ b/types/deadlines.ts
@@ -57,7 +57,7 @@ export type Question = {
   type: QUESTION_TYPE;
   options?: Option[];
   isAnonymous?: boolean;
-  isRequired: boolean;
+  isRequired?: boolean;
 };
 
 export type LeanQuestion = Omit<

--- a/types/deadlines.ts
+++ b/types/deadlines.ts
@@ -57,6 +57,7 @@ export type Question = {
   type: QUESTION_TYPE;
   options?: Option[];
   isAnonymous?: boolean;
+  isRequired: boolean;
 };
 
 export type LeanQuestion = Omit<


### PR DESCRIPTION
## Description
PR contains code that does the following changes and ensures that frontend is able to...

1. Toggle the `Required` button in the Edit Question Page.
2.  The respondents will know if the Question is marked as `Required`.
3. Submission could only be done if all `Required` questions are filled in. Otherwise, a snack bar error would be displayed, prohibiting users from submitting.
4. Fix the toggle button issue - now the `Anonymous` and `Required` toggle button should sync with the DB state.
5. Rename `Saved Draft` Status to `In Progress` to minimise confusion.

## Steps to Test
1. Navigate to the `Edit Question` View (When logging in as an Admin, press `MANAGE` --> `Deadlines and Questions` --> press `QUESTIONS` for any deadlines -- preferably for Milestone deadline for easier testing in the later steps).
2. Check 1: There should be a `Required` Toggle Button present beside the `Anonymous Toggle Button`. 
   
   <img width="1847" height="591" alt="image" src="https://github.com/user-attachments/assets/35c3cb2e-7e55-42b3-979c-bfdd864a7aed" />

3. Press the `Required` button once such that the question is now marked as `Required`. Click `SAVE` to save the choice.

    <img width="1853" height="599" alt="image" src="https://github.com/user-attachments/assets/f2eec7b0-c92b-4bdd-91e8-78f6d01c2754" />

5. When pressing the `Preview Questions` toggle in the same page, the `Required` Label should be shown beside the question - indicating that completion of the question is required before submission. 
    
    <img width="1861" height="321" alt="image" src="https://github.com/user-attachments/assets/3cc3f8f1-5006-4ddb-850a-bec616008df5" />

6. Upon pressing the `Preview Questions` toggle again to head back to the `Edit Question` View, the state of the Required toggle should remain the same (instead of switching to the default off state).

    <img width="400" height="73" alt="image" src="https://github.com/user-attachments/assets/fe8e780f-7bbe-48a8-b3e0-203637ac751f" />


8. Navigate to the Student's Preview. (`MANAGE` --> `Users` --> `PREVIEW` for any students)
9. Without filling in the question with `Required` label and pressing submit, there will be an error displayed, prohibiting the users from submitting. 

    <img width="1842" height="506" alt="image" src="https://github.com/user-attachments/assets/7785a6d6-4113-485a-aca9-a722f8e01a31" />

10. Upon pressing the `BACK` button, you should see the status as `IN PROGRESS` for the milestone that you have failed to submit in 6.
    
    <img width="1761" height="65" alt="image" src="https://github.com/user-attachments/assets/52747ba1-d823-4b78-b128-c5345e8420bd" />

11. When trying to resubmit after filling in the questions accordingly, submit button would then work as intended without any error displayed. 

    <img width="1850" height="511" alt="image" src="https://github.com/user-attachments/assets/f41a830b-917e-4b08-b602-219958cdcd53" />