### PR TITLE
fix: public gallery cohort SSG routes

### DIFF
--- a/__tests__/pages/public-gallery-page.ssg.test.ts
+++ b/__tests__/pages/public-gallery-page.ssg.test.ts
@@ -3,14 +3,10 @@
 // @ts-nocheck
 
 /**
- * Unit tests for SSG functions in pages/public-gallery/[level]/page/[page].tsx
- *
- * Tests getStaticPaths() and getStaticProps() for per-achievement paginated gallery pages:
- * - getStaticPaths: generates paths for each achievement level × page combination
- * - getStaticProps: fetches paginated project data filtered by achievement level
+ * Unit tests for cohort-aware SSG functions in
+ * pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
  */
 
-// Mock React component dependencies to avoid import resolution issues
 jest.mock("@/components/cards/ProjectCard/ProjectCard", () => {
   function MockProjectCard() {
     return null;
@@ -25,14 +21,8 @@ jest.mock("@/components/layout/CustomHead", () => {
   MockCustomHead.displayName = "MockCustomHead";
   return MockCustomHead;
 });
-jest.mock("@/helpers/publicGallery", () => ({
-  filterProjects: jest.fn(),
-  extractCohortYears: jest.fn(() => []),
-  getMostRecentCohort: jest.fn(() => ""),
-}));
 jest.mock("@/styles/constants", () => ({}));
 
-// Mock SSG config
 jest.mock("@/ssg/config/ssg", () => ({
   PAGE_SIZE: 28,
   MAX_PAGES_TO_PREBUILD: 10,
@@ -40,69 +30,57 @@ jest.mock("@/ssg/config/ssg", () => ({
   getApiUrl: () => "http://localhost:4000/api",
 }));
 
-// Mock the API module with inline ApiError class
+const mockFetchPublicProjectCohortsFn = jest.fn();
 const mockFetchPublicProjectsCountFn = jest.fn();
 const mockFetchPublicProjectsFn = jest.fn();
 
-jest.mock("@/lib/api/projectsApi", () => {
-  class ApiError extends Error {
-    statusCode: number;
-    endpoint: string;
-    constructor(message: string, statusCode: number, endpoint: string) {
-      super(message);
-      this.name = "ApiError";
-      this.statusCode = statusCode;
-      this.endpoint = endpoint;
-    }
-  }
-  return {
-    __esModule: true,
-    fetchPublicProjectsCount: (...args: any[]) =>
-      mockFetchPublicProjectsCountFn(...args),
-    fetchPublicProjects: (...args: any[]) => mockFetchPublicProjectsFn(...args),
-    ApiError,
-  };
-});
+jest.mock("@/lib/api/projectsApi", () => ({
+  __esModule: true,
+  fetchPublicProjectCohorts: (...args: any[]) =>
+    mockFetchPublicProjectCohortsFn(...args),
+  fetchPublicProjectsCount: (...args: any[]) =>
+    mockFetchPublicProjectsCountFn(...args),
+  fetchPublicProjects: (...args: any[]) => mockFetchPublicProjectsFn(...args),
+}));
 
-// Import after mocks are set up
 import {
   getStaticPaths,
   getStaticProps,
-} from "../../pages/public-gallery/[level]/page/[page]";
-import { ApiError } from "@/lib/api/projectsApi";
+} from "../../pages/public-gallery/[cohortYear]/[level]/page/[page]";
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Suppress console.error for expected error scenarios
-  jest.spyOn(console, "error").mockImplementation(() => null);
 });
 
 describe("getStaticPaths", () => {
-  it("generates paths for each level and caps pages at MAX_PAGES_TO_PREBUILD", async () => {
+  it("generates paths for each public cohort, level, and page", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
     mockFetchPublicProjectsCountFn.mockResolvedValue({
-      total: 500,
-      totalPages: 18,
+      total: 56,
+      totalPages: 2,
     });
 
     const result = await getStaticPaths({});
 
-    // Should call fetchPublicProjectsCount for each of 4 levels (artemis, apollo, gemini, vostok)
-    expect(mockFetchPublicProjectsCountFn).toHaveBeenCalledTimes(4);
-    // Each level should have up to MAX_PAGES_TO_PREBUILD (10) pages
-    expect(result.paths.length).toBe(40); // 4 levels × 10 pages
-    expect(result.paths[0]).toEqual({
-      params: { level: "artemis", page: "1" },
+    expect(mockFetchPublicProjectCohortsFn).toHaveBeenCalledTimes(1);
+    expect(mockFetchPublicProjectsCountFn).toHaveBeenCalledTimes(8);
+    expect(mockFetchPublicProjectsCountFn).toHaveBeenCalledWith(
+      28,
+      "artemis",
+      2026
+    );
+    expect(result.paths).toContainEqual({
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
     });
-    expect(result.paths[9]).toEqual({
-      params: { level: "artemis", page: "10" },
+    expect(result.paths).toContainEqual({
+      params: { cohortYear: "2025", level: "vostok", page: "2" },
     });
-    expect(result.paths[10]).toEqual({
-      params: { level: "apollo", page: "1" },
-    });
+    expect(result.paths.length).toBe(16);
     expect(result.fallback).toBe(false);
   });
 
-  it("generates at least 1 page per level when totalPages is 0 (empty DB)", async () => {
+  it("generates at least one page for empty cohort-level combinations", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
     mockFetchPublicProjectsCountFn.mockResolvedValue({
       total: 0,
       totalPages: 0,
@@ -110,72 +88,30 @@ describe("getStaticPaths", () => {
 
     const result = await getStaticPaths({});
 
-    expect(result.paths.length).toBe(4); // 4 levels × 1 page each
+    expect(result.paths.length).toBe(4);
     expect(result.paths[0]).toEqual({
-      params: { level: "artemis", page: "1" },
-    });
-    expect(result.paths[1]).toEqual({ params: { level: "apollo", page: "1" } });
-  });
-
-  it("falls back to single page per level on API error", async () => {
-    mockFetchPublicProjectsCountFn.mockRejectedValue(
-      new ApiError(
-        "Server Error",
-        500,
-        "/projects/public/count?achievement=artemis"
-      )
-    );
-
-    const result = await getStaticPaths({});
-
-    expect(result.paths.length).toBe(4); // 4 levels × 1 page fallback each
-    expect(result.paths[0]).toEqual({
-      params: { level: "artemis", page: "1" },
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
     });
   });
 
-  it("logs error with context on ApiError per level", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error");
-    mockFetchPublicProjectsCountFn.mockRejectedValue(
-      new ApiError(
-        "Server Error",
-        500,
-        "/projects/public/count?achievement=artemis"
-      )
-    );
-
-    await getStaticPaths({});
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[SSG] Failed to fetch paths for"),
-      expect.stringContaining("API Error (500)")
-    );
-  });
-
-  it("logs error on unknown error per level", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error");
-    mockFetchPublicProjectsCountFn.mockRejectedValue(
+  it("fails the build when cohort discovery fails", async () => {
+    mockFetchPublicProjectCohortsFn.mockRejectedValue(
       new Error("Connection refused")
     );
 
-    await getStaticPaths({});
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[SSG] Failed to fetch paths for"),
-      expect.stringContaining("Unknown error")
-    );
+    await expect(getStaticPaths({})).rejects.toThrow("Connection refused");
   });
 });
 
 describe("getStaticProps", () => {
-  const mockProjectsResponse = {
+  const page1Response = {
     projects: [
       {
         id: 1,
         name: "Project 1",
         teamName: "Team 1",
         achievement: "Artemis",
-        cohortYear: 2024,
+        cohortYear: 2026,
         hasDropped: false,
       },
     ],
@@ -185,48 +121,31 @@ describe("getStaticProps", () => {
     totalPages: 2,
   };
 
-  it("fetches projects for a level and returns props with correct structure", async () => {
-    // Mock returns different data for page 1 and page 2
-    const page1Response = {
-      projects: [
-        {
-          id: 1,
-          name: "Project 1",
-          teamName: "Team 1",
-          achievement: "Artemis",
-          cohortYear: 2024,
-          hasDropped: false,
-        },
-      ],
-      total: 50,
-      page: 1,
-      pageSize: 28,
-      totalPages: 2,
-    };
+  const page2Response = {
+    projects: [
+      {
+        id: 2,
+        name: "Project 2",
+        teamName: "Team 2",
+        achievement: "Artemis",
+        cohortYear: 2026,
+        hasDropped: false,
+      },
+    ],
+    total: 50,
+    page: 2,
+    pageSize: 28,
+    totalPages: 2,
+  };
 
-    const page2Response = {
-      projects: [
-        {
-          id: 2,
-          name: "Project 2",
-          teamName: "Team 2",
-          achievement: "Artemis",
-          cohortYear: 2024,
-          hasDropped: false,
-        },
-      ],
-      total: 50,
-      page: 2,
-      pageSize: 28,
-      totalPages: 2,
-    };
-
+  it("fetches backend-filtered projects for a cohort and level", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
     mockFetchPublicProjectsFn
       .mockResolvedValueOnce(page1Response)
       .mockResolvedValueOnce(page2Response);
 
     const result = await getStaticProps({
-      params: { level: "artemis", page: "1" },
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
     } as any);
 
     expect(mockFetchPublicProjectsFn).toHaveBeenCalledTimes(2);
@@ -234,13 +153,15 @@ describe("getStaticProps", () => {
       1,
       1,
       28,
-      "Artemis"
+      "Artemis",
+      2026
     );
     expect(mockFetchPublicProjectsFn).toHaveBeenNthCalledWith(
       2,
       2,
       28,
-      "Artemis"
+      "Artemis",
+      2026
     );
     expect(result).toEqual({
       props: {
@@ -249,106 +170,43 @@ describe("getStaticProps", () => {
         totalPages: 2,
         total: 50,
         level: "artemis",
+        cohortYear: 2026,
+        cohortYears: [2026, 2025],
       },
     });
   });
 
-  it("returns notFound when page exceeds totalPages for a level", async () => {
-    const response = { ...mockProjectsResponse, totalPages: 2 };
-    mockFetchPublicProjectsFn.mockResolvedValue(response);
+  it("returns notFound when requested page exceeds cohort-level total pages", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
+    mockFetchPublicProjectsFn.mockResolvedValue({
+      ...page1Response,
+      totalPages: 2,
+    });
 
     const result = await getStaticProps({
-      params: { level: "apollo", page: "5" },
+      params: { cohortYear: "2026", level: "apollo", page: "5" },
     } as any);
 
     expect(result).toEqual({ notFound: true });
   });
 
-  it("handles empty DB (totalPages = 0) gracefully for a level", async () => {
-    const emptyResponse = {
-      projects: [],
-      total: 0,
-      page: 1,
-      pageSize: 28,
-      totalPages: 0,
-    };
-    mockFetchPublicProjectsFn.mockResolvedValue(emptyResponse);
-
+  it("returns notFound for invalid cohort year params", async () => {
     const result = await getStaticProps({
-      params: { level: "gemini", page: "1" },
+      params: { cohortYear: "invalid", level: "gemini", page: "1" },
     } as any);
 
-    expect((result as any).props.projects).toBeDefined();
-    expect((result as any).props.totalPages).toBeGreaterThanOrEqual(1);
-    expect((result as any).props.level).toBe("gemini");
+    expect(result).toEqual({ notFound: true });
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
   });
 
-  it("returns fallback props on API error for a level", async () => {
-    mockFetchPublicProjectsFn.mockRejectedValue(
-      new ApiError(
-        "Internal Error",
-        500,
-        "/projects/public?page=1&limit=28&achievement=Artemis"
-      )
-    );
-    const result = await getStaticProps({
-      params: { level: "artemis", page: "1" },
-    } as any);
+  it("fails the build when public project fetching fails", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
+    mockFetchPublicProjectsFn.mockRejectedValue(new Error("Backend down"));
 
-    expect(result).toEqual({
-      props: {
-        projects: [],
-        currentPage: 1,
-        totalPages: 1,
-        total: 0,
-        level: "artemis",
-      },
-    });
-  });
-
-  it("logs error with context on ApiError for a level", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error");
-    mockFetchPublicProjectsFn.mockRejectedValue(
-      new ApiError(
-        "Server Error",
-        500,
-        "/projects/public?page=1&limit=28&achievement=Apollo"
-      )
-    );
-
-    await getStaticProps({
-      params: { level: "apollo", page: "1" },
-    } as any);
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "[SSG] Failed to fetch apollo projects for page 1"
-      ),
-      expect.stringContaining("API Error (500)")
-    );
-  });
-
-  it("logs error on unknown error for a level", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error");
-    mockFetchPublicProjectsFn.mockRejectedValue(new Error("Timeout"));
-
-    await getStaticProps({
-      params: { level: "vostok", page: "3" },
-    } as any);
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "[SSG] Failed to fetch vostok projects for page 3"
-      ),
-      expect.stringContaining("Unknown error")
-    );
-  });
-
-  it("defaults to page 1 and level artemis for invalid params", async () => {
-    mockFetchPublicProjectsFn.mockResolvedValue(mockProjectsResponse);
-
-    await getStaticProps({ params: {} } as any);
-
-    expect(mockFetchPublicProjectsFn).toHaveBeenCalledWith(1, 28, "Artemis");
+    await expect(
+      getStaticProps({
+        params: { cohortYear: "2026", level: "vostok", page: "1" },
+      } as any)
+    ).rejects.toThrow("Backend down");
   });
 });

--- a/__tests__/pages/public-gallery-page.ssg.test.ts
+++ b/__tests__/pages/public-gallery-page.ssg.test.ts
@@ -25,7 +25,7 @@ jest.mock("@/styles/constants", () => ({}));
 
 jest.mock("@/ssg/config/ssg", () => ({
   PAGE_SIZE: 28,
-  MAX_PAGES_TO_PREBUILD: 10,
+  PUBLIC_GALLERY_BUILD_PAGE_SIZE: 100,
   DEFAULT_PAGE: 1,
   getApiUrl: () => "http://localhost:4000/api",
 }));
@@ -47,17 +47,18 @@ import {
   getStaticPaths,
   getStaticProps,
 } from "../../pages/public-gallery/[cohortYear]/[level]/page/[page]";
+import { getStaticProps as getIndexStaticProps } from "../../pages/public-gallery";
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe("getStaticPaths", () => {
-  it("generates paths for each public cohort, level, and page", async () => {
+  it("generates all paths for each public cohort, level, and page", async () => {
     mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
     mockFetchPublicProjectsCountFn.mockResolvedValue({
-      total: 56,
-      totalPages: 2,
+      total: 336,
+      totalPages: 12,
     });
 
     const result = await getStaticPaths({});
@@ -73,9 +74,9 @@ describe("getStaticPaths", () => {
       params: { cohortYear: "2026", level: "artemis", page: "1" },
     });
     expect(result.paths).toContainEqual({
-      params: { cohortYear: "2025", level: "vostok", page: "2" },
+      params: { cohortYear: "2025", level: "vostok", page: "12" },
     });
-    expect(result.paths.length).toBe(16);
+    expect(result.paths.length).toBe(96);
     expect(result.fallback).toBe(false);
   });
 
@@ -117,7 +118,7 @@ describe("getStaticProps", () => {
     ],
     total: 50,
     page: 1,
-    pageSize: 28,
+    pageSize: 100,
     totalPages: 2,
   };
 
@@ -134,7 +135,7 @@ describe("getStaticProps", () => {
     ],
     total: 50,
     page: 2,
-    pageSize: 28,
+    pageSize: 100,
     totalPages: 2,
   };
 
@@ -152,14 +153,14 @@ describe("getStaticProps", () => {
     expect(mockFetchPublicProjectsFn).toHaveBeenNthCalledWith(
       1,
       1,
-      28,
+      100,
       "Artemis",
       2026
     );
     expect(mockFetchPublicProjectsFn).toHaveBeenNthCalledWith(
       2,
       2,
-      28,
+      100,
       "Artemis",
       2026
     );
@@ -199,6 +200,15 @@ describe("getStaticProps", () => {
     expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
   });
 
+  it("returns notFound for invalid page params", async () => {
+    const result = await getStaticProps({
+      params: { cohortYear: "2026", level: "gemini", page: "-1" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+  });
+
   it("fails the build when public project fetching fails", async () => {
     mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
     mockFetchPublicProjectsFn.mockRejectedValue(new Error("Backend down"));
@@ -208,5 +218,63 @@ describe("getStaticProps", () => {
         params: { cohortYear: "2026", level: "vostok", page: "1" },
       } as any)
     ).rejects.toThrow("Backend down");
+  });
+});
+
+describe("index getStaticProps", () => {
+  const project = {
+    id: 1,
+    name: "Project 1",
+    teamName: "Team 1",
+    achievement: "Artemis",
+    cohortYear: 2026,
+    hasDropped: false,
+  };
+
+  it("renders the latest cohort Artemis gallery as static props", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
+    mockFetchPublicProjectsFn.mockResolvedValue({
+      projects: [project],
+      total: 1,
+      page: 1,
+      pageSize: 100,
+      totalPages: 1,
+    });
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectCohortsFn).toHaveBeenCalledTimes(1);
+    expect(mockFetchPublicProjectsFn).toHaveBeenCalledWith(
+      1,
+      100,
+      "Artemis",
+      2026
+    );
+    expect(result).toEqual({
+      props: {
+        galleryProps: {
+          projects: [project],
+          currentPage: 1,
+          totalPages: 1,
+          total: 1,
+          level: "artemis",
+          cohortYear: 2026,
+          cohortYears: [2026, 2025],
+        },
+      },
+    });
+  });
+
+  it("renders a static empty state when no public cohorts exist", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([]);
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        galleryProps: null,
+      },
+    });
   });
 });

--- a/__tests__/pages/public-gallery-projectId.ssg.test.ts
+++ b/__tests__/pages/public-gallery-projectId.ssg.test.ts
@@ -77,7 +77,6 @@ jest.mock("@/lib/api/projectsApi", () => {
 jest.mock("@/ssg/config/ssg", () => ({
   PROJECT_PATHS_PAGE_SIZE: 100,
   PAGE_SIZE: 28,
-  MAX_PAGES_TO_PREBUILD: 10,
   DEFAULT_PAGE: 1,
   getApiUrl: () => "http://localhost:4000/api",
 }));

--- a/components/publicGallery/PublicGalleryPage.tsx
+++ b/components/publicGallery/PublicGalleryPage.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useRef, useState, useEffect } from "react";
+import {
+  Box,
+  Container,
+  Grid,
+  Typography,
+  Pagination,
+  Tabs,
+  Tab,
+  tabsClasses,
+  Stack,
+  TextField,
+  MenuItem,
+} from "@mui/material";
+import { useRouter } from "next/router";
+import Fuse from "fuse.js";
+import ProjectCard from "@/components/cards/ProjectCard/ProjectCard";
+import CustomHead from "@/components/layout/CustomHead";
+import SearchInput from "@/components/search/SearchInput/SearchInput";
+import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
+import { PAGE_SIZE } from "@/ssg/config/ssg";
+import {
+  levelToSlug,
+  PublicGalleryPageProps,
+  slugToLevel,
+} from "@/helpers/publicGallery";
+
+const PublicGalleryPage = ({
+  projects,
+  currentPage,
+  level,
+  cohortYear,
+  cohortYears,
+}: PublicGalleryPageProps) => {
+  const router = useRouter();
+  const selectedLevel = slugToLevel(level);
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(projects, {
+        keys: [
+          "name",
+          "teamName",
+          "students.name",
+          "adviser.name",
+          "mentor.name",
+        ],
+        threshold: 0.3,
+        ignoreLocation: true,
+      }),
+    [projects]
+  );
+
+  const handleSearchChange = (value: string) => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+    searchTimeoutRef.current = setTimeout(() => {
+      setSearchQuery(value);
+    }, 200);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const searchedProjects = useMemo(() => {
+    if (!searchQuery.trim()) return projects;
+    return fuse.search(searchQuery).map((result) => result.item);
+  }, [fuse, searchQuery, projects]);
+
+  const searchedTotalPages = Math.max(
+    Math.ceil(searchedProjects.length / PAGE_SIZE),
+    1
+  );
+  const clientPage = Math.min(currentPage, searchedTotalPages);
+  const paginatedProjects = searchedProjects.slice(
+    (clientPage - 1) * PAGE_SIZE,
+    clientPage * PAGE_SIZE
+  );
+
+  const handleCohortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextCohortYear = Number(event.target.value);
+    router.push({
+      pathname: `/public-gallery/${nextCohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/1/`,
+    });
+  };
+
+  const handleTabChange = (
+    _: React.SyntheticEvent,
+    newLevel: LEVELS_OF_ACHIEVEMENT
+  ) => {
+    router.push({
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        newLevel
+      )}/page/1/`,
+    });
+  };
+
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    router.push({
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/${page}/`,
+    });
+  };
+
+  return (
+    <>
+      <CustomHead
+        title={`${cohortYear} ${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
+      />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box
+          sx={{
+            mb: 4,
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            justifyContent: "space-between",
+            alignItems: { sm: "center" },
+            gap: 2,
+          }}
+        >
+          <Box>
+            <Typography variant="h3" component="h1" gutterBottom>
+              Public Project Gallery
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Explore outstanding {selectedLevel} projects from the Orbital
+              program ({searchedProjects.length} projects in {cohortYear})
+            </Typography>
+          </Box>
+        </Box>
+
+        <Stack direction="column" spacing={2} sx={{ mb: 3 }}>
+          <Box
+            sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
+          >
+            <SearchInput
+              id="project-search"
+              label="Search projects"
+              onChange={handleSearchChange}
+            />
+            <TextField
+              id="cohort-select"
+              name="cohort"
+              label="Cohort"
+              value={cohortYear}
+              onChange={handleCohortChange}
+              select
+              size="small"
+              sx={{ minWidth: 120 }}
+            >
+              {cohortYears.map((year) => (
+                <MenuItem key={year} value={year}>
+                  {year}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+          <Tabs
+            value={selectedLevel}
+            onChange={handleTabChange}
+            textColor="secondary"
+            indicatorColor="secondary"
+            aria-label="achievement-level-tabs"
+            variant="scrollable"
+            scrollButtons="auto"
+            allowScrollButtonsMobile
+            sx={{ [`& .${tabsClasses.scrollButtons}`]: { color: "primary" } }}
+          >
+            {Object.values(LEVELS_OF_ACHIEVEMENT).map((lvl) => (
+              <Tab key={lvl} value={lvl} label={lvl} />
+            ))}
+          </Tabs>
+        </Stack>
+
+        <Grid container spacing={3}>
+          {paginatedProjects.map((project) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={project.id}>
+              <ProjectCard
+                project={project}
+                detailsLinkPath={`/public-gallery/projects/${project.id}`}
+              />
+            </Grid>
+          ))}
+        </Grid>
+
+        {paginatedProjects.length === 0 && (
+          <Box sx={{ textAlign: "center", py: 8 }}>
+            <Typography variant="h6" color="text.secondary">
+              No projects found
+              {searchQuery ? ` matching "${searchQuery}"` : ""}
+              {` in ${cohortYear} for ${selectedLevel}`}
+            </Typography>
+          </Box>
+        )}
+
+        {searchedTotalPages > 1 && (
+          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+            <Pagination
+              count={searchedTotalPages}
+              page={clientPage}
+              onChange={handlePageChange}
+              color="primary"
+              size="large"
+              showFirstButton
+              showLastButton
+            />
+          </Box>
+        )}
+      </Container>
+    </>
+  );
+};
+
+export default PublicGalleryPage;

--- a/cypress/e2e/public-gallery/public-gallery.cy.js
+++ b/cypress/e2e/public-gallery/public-gallery.cy.js
@@ -13,6 +13,10 @@
  */
 
 describe("Public Gallery - SSG Feature", () => {
+  const getSelectedCohortYear = () => {
+    return cy.get('input[name="cohort"]').invoke("val");
+  };
+
   describe("Index Page", () => {
     beforeEach(() => {
       cy.visit("http://localhost:3000/public-gallery/");
@@ -130,11 +134,12 @@ describe("Public Gallery - SSG Feature", () => {
   describe("Paginated Pages (/public-gallery/[cohortYear]/[level]/page/[page])", () => {
     it("renders page 1", () => {
       cy.visit("http://localhost:3000/public-gallery/");
-      cy.location("pathname").should(
-        "match",
-        /\/public-gallery\/\d+\/artemis\/page\/1\//
-      );
-      cy.contains("h1", "Public Project Gallery").should("be.visible");
+      getSelectedCohortYear().then((cohortYear) => {
+        cy.visit(
+          `http://localhost:3000/public-gallery/${cohortYear}/artemis/page/1/`
+        );
+        cy.contains("h1", "Public Project Gallery").should("be.visible");
+      });
     });
 
     it("displays achievement tabs on paginated pages", () => {
@@ -157,12 +162,15 @@ describe("Public Gallery - SSG Feature", () => {
         "aria-selected",
         "true"
       );
+      cy.location("pathname").should(
+        "match",
+        /\/public-gallery\/\d+\/apollo\/page\/1\//
+      );
     });
 
-    it("returns 404 for pages beyond MAX_PAGES_TO_PREBUILD", () => {
+    it("returns 404 for pages beyond generated static pages", () => {
       cy.visit("http://localhost:3000/public-gallery/");
-      cy.location("pathname").then((pathname) => {
-        const cohortYear = pathname.split("/")[2];
+      getSelectedCohortYear().then((cohortYear) => {
         cy.request({
           url: `http://localhost:3000/public-gallery/${cohortYear}/artemis/page/999/`,
           failOnStatusCode: false,

--- a/cypress/e2e/public-gallery/public-gallery.cy.js
+++ b/cypress/e2e/public-gallery/public-gallery.cy.js
@@ -7,7 +7,7 @@
  * 1. Static page rendering and navigation
  * 2. Pagination functionality
  * 3. Achievement level tab filtering (Artemis, Apollo, Gemini, Vostok)
- * 4. Cohort year dropdown filtering (index page only)
+ * 4. Cohort year dropdown routing
  * 5. Project detail page navigation and content
  * 6. Edge cases: empty states, 404 pages
  */
@@ -121,31 +121,35 @@ describe("Public Gallery - SSG Feature", () => {
         if ($body.find('nav[aria-label="pagination navigation"]').length > 0) {
           // Click page 2 button
           cy.get('button[aria-label="Go to page 2"]').click();
-          cy.url().should("include", "/public-gallery/artemis/page/2");
+          cy.url().should("include", "/artemis/page/2");
         }
       });
     });
   });
 
-  describe("Paginated Pages (/public-gallery/[level]/page/[page])", () => {
+  describe("Paginated Pages (/public-gallery/[cohortYear]/[level]/page/[page])", () => {
     it("renders page 1", () => {
-      cy.visit("http://localhost:3000/public-gallery/artemis/page/1/");
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.location("pathname").should(
+        "match",
+        /\/public-gallery\/\d+\/artemis\/page\/1\//
+      );
       cy.contains("h1", "Public Project Gallery").should("be.visible");
     });
 
     it("displays achievement tabs on paginated pages", () => {
-      cy.visit("http://localhost:3000/public-gallery/artemis/page/1/");
+      cy.visit("http://localhost:3000/public-gallery/");
       cy.get('[aria-label="achievement-level-tabs"]').should("be.visible");
       cy.contains("button", "Artemis").should("be.visible");
     });
 
-    it("does NOT display cohort selector on paginated pages", () => {
-      cy.visit("http://localhost:3000/public-gallery/artemis/page/1/");
-      cy.get("#public-gallery-cohort-select").should("not.exist");
+    it("displays cohort selector on paginated pages", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.get("#cohort-select").should("be.visible");
     });
 
     it("allows switching between achievement tabs", () => {
-      cy.visit("http://localhost:3000/public-gallery/artemis/page/1/");
+      cy.visit("http://localhost:3000/public-gallery/");
 
       cy.contains("button", "Apollo").click();
       cy.contains("button", "Apollo").should(
@@ -156,12 +160,15 @@ describe("Public Gallery - SSG Feature", () => {
     });
 
     it("returns 404 for pages beyond MAX_PAGES_TO_PREBUILD", () => {
-      // Page 999 should not exist (beyond max prebuilt pages)
-      cy.request({
-        url: "http://localhost:3000/public-gallery/artemis/page/999/",
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.status).to.eq(404);
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.location("pathname").then((pathname) => {
+        const cohortYear = pathname.split("/")[2];
+        cy.request({
+          url: `http://localhost:3000/public-gallery/${cohortYear}/artemis/page/999/`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404);
+        });
       });
     });
   });

--- a/helpers/publicGallery.ts
+++ b/helpers/publicGallery.ts
@@ -1,5 +1,27 @@
 import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
 
+export type PublicGalleryPageProps = {
+  projects: Project[];
+  currentPage: number;
+  totalPages: number;
+  total: number;
+  level: string;
+  cohortYear: number;
+  cohortYears: number[];
+};
+
+export const slugToLevel = (slug: string): LEVELS_OF_ACHIEVEMENT => {
+  const pascalCase = slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
+  const matchingLevel = Object.values(LEVELS_OF_ACHIEVEMENT).find(
+    (level) => level === pascalCase
+  );
+  return matchingLevel || LEVELS_OF_ACHIEVEMENT.ARTEMIS;
+};
+
+export const levelToSlug = (level: LEVELS_OF_ACHIEVEMENT): string => {
+  return level.toLowerCase();
+};
+
 /**
  * Filters projects by achievement level and cohort year for public gallery display
  */

--- a/lib/api/projectsApi.ts
+++ b/lib/api/projectsApi.ts
@@ -4,9 +4,7 @@
  */
 
 import { Project } from "@/types/projects";
-import { PAGE_SIZE } from "@/ssg/config/ssg";
-import { ApiServiceBuilder } from "@/helpers/api";
-import { HTTP_METHOD } from "@/types/api";
+import { getApiUrl, PAGE_SIZE } from "@/ssg/config/ssg";
 
 /**
  * Response shape from GET /projects/public
@@ -25,6 +23,13 @@ export interface PaginatedProjectsResponse {
 export interface ProjectsCountResponse {
   total: number;
   totalPages: number;
+}
+
+/**
+ * Response shape from GET /projects/public/cohorts
+ */
+export interface PublicProjectCohortsResponse {
+  cohortYears: number[];
 }
 
 /**
@@ -48,6 +53,40 @@ export class ApiError extends Error {
   }
 }
 
+function buildUrl(
+  endpoint: string,
+  queryParams: Record<string, string | number | undefined> = {}
+) {
+  const baseUrl = getApiUrl().replace(/\/$/, "");
+  const url = new URL(`${baseUrl}${endpoint}`);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  return url.toString();
+}
+
+async function fetchJson<T>(
+  endpoint: string,
+  queryParams: Record<string, string | number | undefined> = {}
+): Promise<T> {
+  const url = buildUrl(endpoint, queryParams);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new ApiError(
+      `Failed to fetch ${endpoint}: ${response.statusText}`,
+      response.status,
+      url
+    );
+  }
+
+  return response.json();
+}
+
 /**
  * Fetch paginated public projects
  *
@@ -60,32 +99,15 @@ export class ApiError extends Error {
 export async function fetchPublicProjects(
   page = 1,
   limit = PAGE_SIZE,
-  achievement?: string
+  achievement?: string,
+  cohortYear?: number
 ): Promise<PaginatedProjectsResponse> {
-  const queryParams: Record<string, string | number> = { page, limit };
-  if (achievement) {
-    queryParams.achievement = achievement;
-  }
-
-  const apiService = new ApiServiceBuilder({
-    method: HTTP_METHOD.GET,
-    endpoint: "/projects/public",
-    queryParams,
-  }).build();
-
-  const response = await apiService();
-
-  if (!response.ok) {
-    throw new ApiError(
-      `Failed to fetch public projects: ${response.statusText}`,
-      response.status,
-      `/projects/public?page=${page}&limit=${limit}${
-        achievement ? `&achievement=${achievement}` : ""
-      }`
-    );
-  }
-
-  return response.json();
+  return fetchJson<PaginatedProjectsResponse>("/projects/public", {
+    page,
+    limit,
+    achievement,
+    cohortYear,
+  });
 }
 
 /**
@@ -99,30 +121,24 @@ export async function fetchPublicProjects(
  */
 export async function fetchPublicProjectsCount(
   limit: number = PAGE_SIZE,
-  achievement?: string
+  achievement?: string,
+  cohortYear?: number
 ): Promise<ProjectsCountResponse> {
-  const queryParams: Record<string, string | number> = { limit };
-  if (achievement) {
-    queryParams.achievement = achievement;
-  }
+  return fetchJson<ProjectsCountResponse>("/projects/public/count", {
+    limit,
+    achievement,
+    cohortYear,
+  });
+}
 
-  const apiService = new ApiServiceBuilder({
-    method: HTTP_METHOD.GET,
-    endpoint: "/projects/public/count",
-    queryParams,
-  }).build();
-
-  const response = await apiService();
-
-  if (!response.ok) {
-    throw new ApiError(
-      `Failed to fetch projects count: ${response.statusText}`,
-      response.status,
-      `/projects/public/count?limit=${limit}`
-    );
-  }
-
-  return response.json();
+/**
+ * Fetch cohort years that have public projects
+ */
+export async function fetchPublicProjectCohorts(): Promise<number[]> {
+  const response = await fetchJson<PublicProjectCohortsResponse>(
+    "/projects/public/cohorts"
+  );
+  return response.cohortYears;
 }
 
 /**
@@ -135,22 +151,7 @@ export async function fetchPublicProjectsCount(
 export async function fetchProjectById(
   projectId: string | number
 ): Promise<ProjectResponse> {
-  const apiService = new ApiServiceBuilder({
-    method: HTTP_METHOD.GET,
-    endpoint: `/projects/${projectId}`,
-  }).build();
-
-  const response = await apiService();
-
-  if (!response.ok) {
-    throw new ApiError(
-      `Failed to fetch project ${projectId}: ${response.statusText}`,
-      response.status,
-      `/projects/${projectId}`
-    );
-  }
-
-  return response.json();
+  return fetchJson<ProjectResponse>(`/projects/${projectId}`);
 }
 
 /**

--- a/next.config.js
+++ b/next.config.js
@@ -5,16 +5,6 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  async rewrites() {
-    return {
-      beforeFiles: [
-        {
-          source: "/public-gallery/",
-          destination: "/public-gallery/artemis/page/1/",
-        },
-      ],
-    };
-  },
 };
 
 module.exports = nextConfig;

--- a/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
+++ b/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
@@ -1,282 +1,20 @@
 /* eslint-disable react/prop-types */
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { useMemo, useRef, useState, useEffect } from "react";
+import PublicGalleryPage from "@/components/publicGallery/PublicGalleryPage";
+import { PublicGalleryPageProps } from "@/helpers/publicGallery";
 import {
-  Box,
-  Container,
-  Grid,
-  Typography,
-  Pagination,
-  Tabs,
-  Tab,
-  tabsClasses,
-  Stack,
-  TextField,
-  MenuItem,
-} from "@mui/material";
-import { useRouter } from "next/router";
-import Fuse from "fuse.js";
-import ProjectCard from "@/components/cards/ProjectCard/ProjectCard";
-import CustomHead from "@/components/layout/CustomHead";
-import SearchInput from "@/components/search/SearchInput/SearchInput";
-import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
-import { PAGE_SIZE, MAX_PAGES_TO_PREBUILD } from "@/ssg/config/ssg";
-import {
-  fetchPublicProjectCohorts,
-  fetchPublicProjects,
-  fetchPublicProjectsCount,
-} from "@/lib/api/projectsApi";
+  buildPublicGalleryPageProps,
+  getPublicGalleryStaticPaths,
+} from "@/ssg/publicGallery";
 
-type Props = {
-  projects: Project[];
-  currentPage: number;
-  totalPages: number;
-  total: number;
-  level: string;
-  cohortYear: number;
-  cohortYears: number[];
-};
-
-const slugToLevel = (slug: string): LEVELS_OF_ACHIEVEMENT => {
-  const pascalCase = slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
-  const matchingLevel = Object.values(LEVELS_OF_ACHIEVEMENT).find(
-    (level) => level === pascalCase
-  );
-  return matchingLevel || LEVELS_OF_ACHIEVEMENT.ARTEMIS;
-};
-
-const levelToSlug = (level: LEVELS_OF_ACHIEVEMENT): string => {
-  return level.toLowerCase();
-};
-
-const PublicGalleryCohortLevelPage: NextPage<Props> = ({
-  projects,
-  currentPage,
-  level,
-  cohortYear,
-  cohortYears,
-}) => {
-  const router = useRouter();
-  const selectedLevel = slugToLevel(level);
-  const [searchQuery, setSearchQuery] = useState("");
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const fuse = useMemo(
-    () =>
-      new Fuse(projects, {
-        keys: [
-          "name",
-          "teamName",
-          "students.name",
-          "adviser.name",
-          "mentor.name",
-        ],
-        threshold: 0.3,
-        ignoreLocation: true,
-      }),
-    [projects]
-  );
-
-  const handleSearchChange = (value: string) => {
-    if (searchTimeoutRef.current) {
-      clearTimeout(searchTimeoutRef.current);
-    }
-    searchTimeoutRef.current = setTimeout(() => {
-      setSearchQuery(value);
-    }, 200);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const searchedProjects = useMemo(() => {
-    if (!searchQuery.trim()) return projects;
-    return fuse.search(searchQuery).map((result) => result.item);
-  }, [fuse, searchQuery, projects]);
-
-  const searchedTotalPages = Math.max(
-    Math.ceil(searchedProjects.length / PAGE_SIZE),
-    1
-  );
-  const clientPage = Math.min(currentPage, searchedTotalPages);
-  const paginatedProjects = searchedProjects.slice(
-    (clientPage - 1) * PAGE_SIZE,
-    clientPage * PAGE_SIZE
-  );
-
-  const handleCohortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const nextCohortYear = Number(event.target.value);
-    router.push({
-      pathname: `/public-gallery/${nextCohortYear}/${levelToSlug(
-        selectedLevel
-      )}/page/1/`,
-    });
-  };
-
-  const handleTabChange = (
-    _: React.SyntheticEvent,
-    newLevel: LEVELS_OF_ACHIEVEMENT
-  ) => {
-    router.push({
-      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
-        newLevel
-      )}/page/1/`,
-    });
-  };
-
-  const handlePageChange = (
-    _event: React.ChangeEvent<unknown>,
-    page: number
-  ) => {
-    router.push({
-      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
-        selectedLevel
-      )}/page/${page}/`,
-    });
-  };
-
-  return (
-    <>
-      <CustomHead
-        title={`${cohortYear} ${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
-      />
-      <Container maxWidth="xl" sx={{ py: 4 }}>
-        <Box
-          sx={{
-            mb: 4,
-            display: "flex",
-            flexDirection: { xs: "column", sm: "row" },
-            justifyContent: "space-between",
-            alignItems: { sm: "center" },
-            gap: 2,
-          }}
-        >
-          <Box>
-            <Typography variant="h3" component="h1" gutterBottom>
-              Public Project Gallery
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              Explore outstanding {selectedLevel} projects from the Orbital
-              program ({searchedProjects.length} projects in {cohortYear})
-            </Typography>
-          </Box>
-        </Box>
-
-        <Stack direction="column" spacing={2} sx={{ mb: 3 }}>
-          <Box
-            sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
-          >
-            <SearchInput
-              id="project-search"
-              label="Search projects"
-              onChange={handleSearchChange}
-            />
-            <TextField
-              id="cohort-select"
-              name="cohort"
-              label="Cohort"
-              value={cohortYear}
-              onChange={handleCohortChange}
-              select
-              size="small"
-              sx={{ minWidth: 120 }}
-            >
-              {cohortYears.map((year) => (
-                <MenuItem key={year} value={year}>
-                  {year}
-                </MenuItem>
-              ))}
-            </TextField>
-          </Box>
-          <Tabs
-            value={selectedLevel}
-            onChange={handleTabChange}
-            textColor="secondary"
-            indicatorColor="secondary"
-            aria-label="achievement-level-tabs"
-            variant="scrollable"
-            scrollButtons="auto"
-            allowScrollButtonsMobile
-            sx={{ [`& .${tabsClasses.scrollButtons}`]: { color: "primary" } }}
-          >
-            {Object.values(LEVELS_OF_ACHIEVEMENT).map((lvl) => (
-              <Tab key={lvl} value={lvl} label={lvl} />
-            ))}
-          </Tabs>
-        </Stack>
-
-        <Grid container spacing={3}>
-          {paginatedProjects.map((project) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={project.id}>
-              <ProjectCard
-                project={project}
-                detailsLinkPath={`/public-gallery/projects/${project.id}`}
-              />
-            </Grid>
-          ))}
-        </Grid>
-
-        {paginatedProjects.length === 0 && (
-          <Box sx={{ textAlign: "center", py: 8 }}>
-            <Typography variant="h6" color="text.secondary">
-              No projects found
-              {searchQuery ? ` matching "${searchQuery}"` : ""}
-              {` in ${cohortYear} for ${selectedLevel}`}
-            </Typography>
-          </Box>
-        )}
-
-        {searchedTotalPages > 1 && (
-          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
-            <Pagination
-              count={searchedTotalPages}
-              page={clientPage}
-              onChange={handlePageChange}
-              color="primary"
-              size="large"
-              showFirstButton
-              showLastButton
-            />
-          </Box>
-        )}
-      </Container>
-    </>
-  );
+const PublicGalleryCohortLevelPage: NextPage<PublicGalleryPageProps> = (
+  props
+) => {
+  return <PublicGalleryPage {...props} />;
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const cohortYears = await fetchPublicProjectCohorts();
-  const levels = Object.values(LEVELS_OF_ACHIEVEMENT).map((l) =>
-    l.toLowerCase()
-  );
-  const paths: {
-    params: { cohortYear: string; level: string; page: string };
-  }[] = [];
-
-  for (const cohortYear of cohortYears) {
-    for (const level of levels) {
-      const countData = await fetchPublicProjectsCount(
-        PAGE_SIZE,
-        level,
-        cohortYear
-      );
-      const totalPages = Math.min(
-        Math.max(countData.totalPages || 1, 1),
-        MAX_PAGES_TO_PREBUILD
-      );
-
-      for (let p = 1; p <= totalPages; p++) {
-        paths.push({
-          params: { cohortYear: String(cohortYear), level, page: String(p) },
-        });
-      }
-    }
-  }
+  const paths = await getPublicGalleryStaticPaths();
 
   return {
     paths,
@@ -284,49 +22,14 @@ export const getStaticPaths: GetStaticPaths = async () => {
   };
 };
 
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+export const getStaticProps: GetStaticProps<PublicGalleryPageProps> = async ({
+  params,
+}) => {
   const level = (params?.level as string) || "artemis";
   const page = parseInt(params?.page as string) || 1;
   const cohortYear = Number(params?.cohortYear);
-  const achievementLevel = slugToLevel(level);
 
-  if (!Number.isFinite(cohortYear) || cohortYear <= 0) {
-    return { notFound: true };
-  }
-
-  const [firstPageData, cohortYears] = await Promise.all([
-    fetchPublicProjects(1, PAGE_SIZE, achievementLevel, cohortYear),
-    fetchPublicProjectCohorts(),
-  ]);
-  const { totalPages, total } = firstPageData;
-
-  if ((totalPages === 0 && page > 1) || (totalPages > 0 && page > totalPages)) {
-    return { notFound: true };
-  }
-
-  let allProjects = [...firstPageData.projects];
-
-  for (let p = 2; p <= totalPages; p++) {
-    const pageData = await fetchPublicProjects(
-      p,
-      PAGE_SIZE,
-      achievementLevel,
-      cohortYear
-    );
-    allProjects = allProjects.concat(pageData.projects);
-  }
-
-  return {
-    props: {
-      projects: allProjects,
-      currentPage: page,
-      totalPages: totalPages || 1,
-      total: total || 0,
-      level,
-      cohortYear,
-      cohortYears,
-    },
-  };
+  return buildPublicGalleryPageProps({ cohortYear, level, page });
 };
 
 export default PublicGalleryCohortLevelPage;

--- a/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
+++ b/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import {
   Box,
   Container,
@@ -21,11 +21,10 @@ import CustomHead from "@/components/layout/CustomHead";
 import SearchInput from "@/components/search/SearchInput/SearchInput";
 import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
 import { PAGE_SIZE, MAX_PAGES_TO_PREBUILD } from "@/ssg/config/ssg";
-import { extractCohortYears } from "@/helpers/publicGallery";
 import {
+  fetchPublicProjectCohorts,
   fetchPublicProjects,
   fetchPublicProjectsCount,
-  ApiError,
 } from "@/lib/api/projectsApi";
 
 type Props = {
@@ -34,46 +33,34 @@ type Props = {
   totalPages: number;
   total: number;
   level: string;
+  cohortYear: number;
+  cohortYears: number[];
 };
 
-/** Convert URL slug to LEVELS_OF_ACHIEVEMENT enum */
 const slugToLevel = (slug: string): LEVELS_OF_ACHIEVEMENT => {
-  // Convert lowercase slug (e.g., "artemis") to PascalCase (e.g., "Artemis")
   const pascalCase = slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
-  // Find matching enum value
   const matchingLevel = Object.values(LEVELS_OF_ACHIEVEMENT).find(
     (level) => level === pascalCase
   );
   return matchingLevel || LEVELS_OF_ACHIEVEMENT.ARTEMIS;
 };
 
-/** Convert LEVELS_OF_ACHIEVEMENT to URL slug */
 const levelToSlug = (level: LEVELS_OF_ACHIEVEMENT): string => {
   return level.toLowerCase();
 };
 
-const PublicGalleryLevelPage: NextPage<Props> = ({
+const PublicGalleryCohortLevelPage: NextPage<Props> = ({
   projects,
   currentPage,
   level,
+  cohortYear,
+  cohortYears,
 }) => {
   const router = useRouter();
   const selectedLevel = slugToLevel(level);
-
-  // Extract available cohort years from projects (sorted descending)
-  const cohortYears = useMemo(() => extractCohortYears(projects), [projects]);
-  const mostRecentCohort = cohortYears[0] || "";
-
-  // Initialize cohort from query param or default to most recent
-  const [selectedCohort, setSelectedCohort] = useState<number | "">(
-    mostRecentCohort
-  );
-
-  // Search state
   const [searchQuery, setSearchQuery] = useState("");
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Create Fuse.js instance for fuzzy search
   const fuse = useMemo(
     () =>
       new Fuse(projects, {
@@ -90,7 +77,6 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
     [projects]
   );
 
-  // Debounced search handler
   const handleSearchChange = (value: string) => {
     if (searchTimeoutRef.current) {
       clearTimeout(searchTimeoutRef.current);
@@ -100,7 +86,6 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
     }, 200);
   };
 
-  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
       if (searchTimeoutRef.current) {
@@ -109,69 +94,38 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
     };
   }, []);
 
-  // Sync cohort state with URL query param
-  useEffect(() => {
-    if (router.isReady) {
-      const cohortParam = router.query.cohort;
-      if (cohortParam && !Array.isArray(cohortParam)) {
-        const parsedCohort = parseInt(cohortParam, 10);
-        if (!isNaN(parsedCohort) && cohortYears.includes(parsedCohort)) {
-          setSelectedCohort(parsedCohort);
-        } else {
-          setSelectedCohort(mostRecentCohort);
-        }
-      } else {
-        setSelectedCohort(mostRecentCohort);
-      }
-    }
-  }, [router.isReady, router.query.cohort, cohortYears, mostRecentCohort]);
-
-  // Apply fuzzy search
   const searchedProjects = useMemo(() => {
     if (!searchQuery.trim()) return projects;
     return fuse.search(searchQuery).map((result) => result.item);
   }, [fuse, searchQuery, projects]);
 
-  // Filter projects by selected cohort
-  const filteredProjects = useMemo(() => {
-    if (selectedCohort === "") return searchedProjects;
-    return searchedProjects.filter((p) => p.cohortYear === selectedCohort);
-  }, [searchedProjects, selectedCohort]);
-
-  // Recalculate pagination based on filtered results
-  const filteredTotalPages = Math.max(
-    Math.ceil(filteredProjects.length / PAGE_SIZE),
+  const searchedTotalPages = Math.max(
+    Math.ceil(searchedProjects.length / PAGE_SIZE),
     1
   );
-  const clientPage = Math.min(currentPage, filteredTotalPages);
-  const paginatedProjects = filteredProjects.slice(
+  const clientPage = Math.min(currentPage, searchedTotalPages);
+  const paginatedProjects = searchedProjects.slice(
     (clientPage - 1) * PAGE_SIZE,
     clientPage * PAGE_SIZE
   );
 
   const handleCohortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    const newCohort = value === "" ? "" : parseInt(value, 10);
-    setSelectedCohort(newCohort);
-    // Reset to page 1 and update query param
-    router.push(
-      {
-        pathname: `/public-gallery/${levelToSlug(selectedLevel)}/page/1/`,
-        query: newCohort !== "" ? { cohort: newCohort } : {},
-      },
-      undefined,
-      { shallow: false }
-    );
+    const nextCohortYear = Number(event.target.value);
+    router.push({
+      pathname: `/public-gallery/${nextCohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/1/`,
+    });
   };
 
   const handleTabChange = (
     _: React.SyntheticEvent,
     newLevel: LEVELS_OF_ACHIEVEMENT
   ) => {
-    // Preserve cohort when switching tabs
     router.push({
-      pathname: `/public-gallery/${levelToSlug(newLevel)}/page/1/`,
-      query: selectedCohort !== "" ? { cohort: selectedCohort } : {},
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        newLevel
+      )}/page/1/`,
     });
   };
 
@@ -179,19 +133,17 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
     _event: React.ChangeEvent<unknown>,
     page: number
   ) => {
-    // Preserve cohort when changing pages
     router.push({
-      pathname: `/public-gallery/${levelToSlug(selectedLevel)}/page/${page}/`,
-      query: selectedCohort !== "" ? { cohort: selectedCohort } : {},
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/${page}/`,
     });
   };
 
   return (
     <>
       <CustomHead
-        title={`${
-          selectedCohort !== "" ? `${selectedCohort} ` : ""
-        }${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
+        title={`${cohortYear} ${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
       />
       <Container maxWidth="xl" sx={{ py: 4 }}>
         <Box
@@ -210,8 +162,7 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
             </Typography>
             <Typography variant="body1" color="text.secondary">
               Explore outstanding {selectedLevel} projects from the Orbital
-              program ({filteredProjects.length} projects
-              {selectedCohort !== "" ? ` in ${selectedCohort}` : ""})
+              program ({searchedProjects.length} projects in {cohortYear})
             </Typography>
           </Box>
         </Box>
@@ -229,13 +180,12 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
               id="cohort-select"
               name="cohort"
               label="Cohort"
-              value={selectedCohort}
+              value={cohortYear}
               onChange={handleCohortChange}
               select
               size="small"
               sx={{ minWidth: 120 }}
             >
-              <MenuItem value="">All Cohorts</MenuItem>
               {cohortYears.map((year) => (
                 <MenuItem key={year} value={year}>
                   {year}
@@ -276,16 +226,15 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
             <Typography variant="h6" color="text.secondary">
               No projects found
               {searchQuery ? ` matching "${searchQuery}"` : ""}
-              {selectedCohort !== "" ? ` in ${selectedCohort}` : ""}
-              {` for ${selectedLevel}`}
+              {` in ${cohortYear} for ${selectedLevel}`}
             </Typography>
           </Box>
         )}
 
-        {filteredTotalPages > 1 && (
+        {searchedTotalPages > 1 && (
           <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
             <Pagination
-              count={filteredTotalPages}
+              count={searchedTotalPages}
               page={clientPage}
               onChange={handlePageChange}
               color="primary"
@@ -301,32 +250,31 @@ const PublicGalleryLevelPage: NextPage<Props> = ({
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  const cohortYears = await fetchPublicProjectCohorts();
   const levels = Object.values(LEVELS_OF_ACHIEVEMENT).map((l) =>
     l.toLowerCase()
   );
-  const paths: { params: { level: string; page: string } }[] = [];
+  const paths: {
+    params: { cohortYear: string; level: string; page: string };
+  }[] = [];
 
-  for (const level of levels) {
-    try {
-      const countData = await fetchPublicProjectsCount(PAGE_SIZE, level);
+  for (const cohortYear of cohortYears) {
+    for (const level of levels) {
+      const countData = await fetchPublicProjectsCount(
+        PAGE_SIZE,
+        level,
+        cohortYear
+      );
       const totalPages = Math.min(
         Math.max(countData.totalPages || 1, 1),
         MAX_PAGES_TO_PREBUILD
       );
 
       for (let p = 1; p <= totalPages; p++) {
-        paths.push({ params: { level, page: String(p) } });
+        paths.push({
+          params: { cohortYear: String(cohortYear), level, page: String(p) },
+        });
       }
-    } catch (error) {
-      const errorMessage =
-        error instanceof ApiError
-          ? `API Error (${error.statusCode}): ${error.message}`
-          : `Unknown error: ${error}`;
-
-      console.error(`[SSG] Failed to fetch paths for ${level}:`, errorMessage);
-
-      // Fallback to single page for this level
-      paths.push({ params: { level, page: "1" } });
     }
   }
 
@@ -339,63 +287,46 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
   const level = (params?.level as string) || "artemis";
   const page = parseInt(params?.page as string) || 1;
+  const cohortYear = Number(params?.cohortYear);
   const achievementLevel = slugToLevel(level);
 
-  try {
-    // Fetch first page to get total count
-    const firstPageData = await fetchPublicProjects(
-      1,
-      PAGE_SIZE,
-      achievementLevel
-    );
-    const { totalPages, total } = firstPageData;
-
-    // Fetch ALL projects for this level so client-side cohort filtering works
-    let allProjects = [...firstPageData.projects];
-
-    for (let p = 2; p <= totalPages; p++) {
-      const pageData = await fetchPublicProjects(
-        p,
-        PAGE_SIZE,
-        achievementLevel
-      );
-      allProjects = allProjects.concat(pageData.projects);
-    }
-
-    if (page > totalPages && totalPages > 0) {
-      return { notFound: true };
-    }
-
-    return {
-      props: {
-        projects: allProjects,
-        currentPage: page,
-        totalPages: totalPages || 1,
-        total: total || 0,
-        level,
-      },
-    };
-  } catch (error) {
-    const errorMessage =
-      error instanceof ApiError
-        ? `API Error (${error.statusCode}): ${error.message} at ${error.endpoint}`
-        : `Unknown error: ${error}`;
-
-    console.error(
-      `[SSG] Failed to fetch ${level} projects for page ${page}:`,
-      errorMessage
-    );
-
-    return {
-      props: {
-        projects: [],
-        currentPage: page,
-        totalPages: 1,
-        total: 0,
-        level,
-      },
-    };
+  if (!Number.isFinite(cohortYear) || cohortYear <= 0) {
+    return { notFound: true };
   }
+
+  const [firstPageData, cohortYears] = await Promise.all([
+    fetchPublicProjects(1, PAGE_SIZE, achievementLevel, cohortYear),
+    fetchPublicProjectCohorts(),
+  ]);
+  const { totalPages, total } = firstPageData;
+
+  if ((totalPages === 0 && page > 1) || (totalPages > 0 && page > totalPages)) {
+    return { notFound: true };
+  }
+
+  let allProjects = [...firstPageData.projects];
+
+  for (let p = 2; p <= totalPages; p++) {
+    const pageData = await fetchPublicProjects(
+      p,
+      PAGE_SIZE,
+      achievementLevel,
+      cohortYear
+    );
+    allProjects = allProjects.concat(pageData.projects);
+  }
+
+  return {
+    props: {
+      projects: allProjects,
+      currentPage: page,
+      totalPages: totalPages || 1,
+      total: total || 0,
+      level,
+      cohortYear,
+      cohortYears,
+    },
+  };
 };
 
-export default PublicGalleryLevelPage;
+export default PublicGalleryCohortLevelPage;

--- a/pages/public-gallery/index.tsx
+++ b/pages/public-gallery/index.tsx
@@ -1,13 +1,39 @@
 /* eslint-disable react/prop-types */
+import { GetStaticProps } from "next";
 import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { fetchPublicProjectCohorts } from "@/lib/api/projectsApi";
+
+type Props = {
+  latestCohortYear: number | null;
+};
 
 /**
  * Public gallery index page
- * This page is rewritten to /public-gallery/artemis/page/1
- * by the next.config.js rewrite rule
+ * This page routes to the newest cohort's Artemis page on the client.
  */
-const PublicGalleryIndex: NextPage = () => {
+const PublicGalleryIndex: NextPage<Props> = ({ latestCohortYear }) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (latestCohortYear) {
+      router.replace(`/public-gallery/${latestCohortYear}/artemis/page/1/`);
+    }
+  }, [latestCohortYear, router]);
+
   return null;
+};
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const cohortYears = await fetchPublicProjectCohorts();
+  const latestCohortYear = cohortYears[0];
+
+  return {
+    props: {
+      latestCohortYear: latestCohortYear || null,
+    },
+  };
 };
 
 export default PublicGalleryIndex;

--- a/pages/public-gallery/index.tsx
+++ b/pages/public-gallery/index.tsx
@@ -1,37 +1,65 @@
 /* eslint-disable react/prop-types */
 import { GetStaticProps } from "next";
 import type { NextPage } from "next";
-import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { Box, Container, Typography } from "@mui/material";
+import CustomHead from "@/components/layout/CustomHead";
+import PublicGalleryPage from "@/components/publicGallery/PublicGalleryPage";
+import { PublicGalleryPageProps } from "@/helpers/publicGallery";
 import { fetchPublicProjectCohorts } from "@/lib/api/projectsApi";
+import { buildPublicGalleryPageProps } from "@/ssg/publicGallery";
 
 type Props = {
-  latestCohortYear: number | null;
+  galleryProps: PublicGalleryPageProps | null;
 };
 
 /**
  * Public gallery index page
- * This page routes to the newest cohort's Artemis page on the client.
+ * This page statically renders the newest cohort's Artemis page.
  */
-const PublicGalleryIndex: NextPage<Props> = ({ latestCohortYear }) => {
-  const router = useRouter();
+const PublicGalleryIndex: NextPage<Props> = ({ galleryProps }) => {
+  if (galleryProps) {
+    return <PublicGalleryPage {...galleryProps} />;
+  }
 
-  useEffect(() => {
-    if (latestCohortYear) {
-      router.replace(`/public-gallery/${latestCohortYear}/artemis/page/1/`);
-    }
-  }, [latestCohortYear, router]);
-
-  return null;
+  return (
+    <>
+      <CustomHead title="Public Project Gallery" />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box>
+          <Typography variant="h3" component="h1" gutterBottom>
+            Public Project Gallery
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            No public projects found
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
 };
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   const cohortYears = await fetchPublicProjectCohorts();
   const latestCohortYear = cohortYears[0];
 
+  if (!latestCohortYear) {
+    return {
+      props: {
+        galleryProps: null,
+      },
+    };
+  }
+
+  const result = await buildPublicGalleryPageProps({
+    cohortYear: latestCohortYear,
+    level: "artemis",
+    page: 1,
+    cohortYears,
+  });
+
   return {
     props: {
-      latestCohortYear: latestCohortYear || null,
+      galleryProps: "props" in result ? result.props : null,
     },
   };
 };

--- a/ssg/config/ssg.ts
+++ b/ssg/config/ssg.ts
@@ -12,16 +12,16 @@
 export const PAGE_SIZE = 28;
 
 /**
- * Maximum number of pages to prebuild during static generation
- * Limits build time while covering most projects (10 pages × 28 = 280 projects)
- */
-export const MAX_PAGES_TO_PREBUILD = 10;
-
-/**
  * Page size used when fetching all project IDs for detail page generation
  * Larger size reduces API calls during build
  */
 export const PROJECT_PATHS_PAGE_SIZE = 100;
+
+/**
+ * Page size used when fetching all projects for a statically generated gallery page
+ * Larger size reduces API calls during build while rendered pages still use PAGE_SIZE
+ */
+export const PUBLIC_GALLERY_BUILD_PAGE_SIZE = 100;
 
 /**
  * Default page number when none is specified

--- a/ssg/publicGallery.ts
+++ b/ssg/publicGallery.ts
@@ -1,0 +1,104 @@
+import { GetStaticPropsResult } from "next";
+import { PublicGalleryPageProps, slugToLevel } from "@/helpers/publicGallery";
+import { PAGE_SIZE, PUBLIC_GALLERY_BUILD_PAGE_SIZE } from "@/ssg/config/ssg";
+import {
+  fetchPublicProjectCohorts,
+  fetchPublicProjects,
+  fetchPublicProjectsCount,
+} from "@/lib/api/projectsApi";
+import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
+
+type BuildPublicGalleryPagePropsParams = {
+  cohortYear: number;
+  level: string;
+  page: number;
+  cohortYears?: number[];
+};
+
+export const getPublicGalleryStaticPaths = async () => {
+  const cohortYears = await fetchPublicProjectCohorts();
+  const levels = Object.values(LEVELS_OF_ACHIEVEMENT).map((l) =>
+    l.toLowerCase()
+  );
+  const paths: {
+    params: { cohortYear: string; level: string; page: string };
+  }[] = [];
+
+  for (const cohortYear of cohortYears) {
+    for (const level of levels) {
+      const countData = await fetchPublicProjectsCount(
+        PAGE_SIZE,
+        level,
+        cohortYear
+      );
+      const totalPages = Math.max(countData.totalPages || 1, 1);
+
+      for (let p = 1; p <= totalPages; p++) {
+        paths.push({
+          params: { cohortYear: String(cohortYear), level, page: String(p) },
+        });
+      }
+    }
+  }
+
+  return paths;
+};
+
+export const buildPublicGalleryPageProps = async ({
+  cohortYear,
+  level,
+  page,
+  cohortYears,
+}: BuildPublicGalleryPagePropsParams): Promise<
+  GetStaticPropsResult<PublicGalleryPageProps>
+> => {
+  const achievementLevel = slugToLevel(level);
+
+  if (!Number.isFinite(cohortYear) || cohortYear <= 0 || page <= 0) {
+    return { notFound: true };
+  }
+
+  const [firstPageData, resolvedCohortYears] = await Promise.all([
+    fetchPublicProjects(
+      1,
+      PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+      achievementLevel,
+      cohortYear
+    ),
+    cohortYears ? Promise.resolve(cohortYears) : fetchPublicProjectCohorts(),
+  ]);
+
+  const displayTotalPages =
+    firstPageData.total > 0 ? Math.ceil(firstPageData.total / PAGE_SIZE) : 0;
+
+  if (
+    (displayTotalPages === 0 && page > 1) ||
+    (displayTotalPages > 0 && page > displayTotalPages)
+  ) {
+    return { notFound: true };
+  }
+
+  let allProjects = [...firstPageData.projects];
+
+  for (let p = 2; p <= firstPageData.totalPages; p++) {
+    const pageData = await fetchPublicProjects(
+      p,
+      PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+      achievementLevel,
+      cohortYear
+    );
+    allProjects = allProjects.concat(pageData.projects);
+  }
+
+  return {
+    props: {
+      projects: allProjects,
+      currentPage: page,
+      totalPages: displayTotalPages || 1,
+      total: firstPageData.total || 0,
+      level,
+      cohortYear,
+      cohortYears: resolvedCohortYears,
+    },
+  };
+};


### PR DESCRIPTION
## Summary

This PR updates the public gallery SSG flow to support cohort-specific gallery pages and fixes the latest frontend review issues around static pagination and `/public-gallery` rendering.

## Changes

- Adds the cohort-aware SSG route:
  - `/public-gallery/[cohortYear]/[level]/page/[page]`
- Removes the legacy conflicting route:
  - `/public-gallery/[level]/page/[page]`
- Updates public gallery data fetching to pass `cohortYear` to the backend for projects and counts.
- Adds `fetchPublicProjectCohorts()` to retrieve available cohort years for static path generation.
- Updates `/public-gallery` to render the latest cohort’s Artemis gallery as static HTML instead of relying on a blank client-side redirect.
- Extracts the public gallery UI into a shared `PublicGalleryPage` component so `/public-gallery` and the cohort route use the same rendering path.
- Removes the old Next.js rewrite for `/public-gallery`.
- Removes the page prebuild cap so every backend-reported public gallery pagination page is statically generated.
- Updates public gallery Jest and Cypress tests for cohort-aware URLs, static index rendering, and full SSG pagination coverage.

## Testing

- `npm test -- --runTestsByPath __tests__/pages/public-gallery-page.ssg.test.ts __tests__/pages/public-gallery-projectId.ssg.test.ts helpers/publicGallery.test.ts --runInBand`
- `npm run build`

