### PR TITLE
fix: fix bug with the summary counter in Admin Dashboard

### DIFF
--- a/components/tables/AllTeamsMilestoneTable/MilestoneSummary/MilestoneSummary.tsx
+++ b/components/tables/AllTeamsMilestoneTable/MilestoneSummary/MilestoneSummary.tsx
@@ -26,7 +26,7 @@ const MilestoneSummary: FC<Props> = ({
       notSubmitted = 0,
       total = 0;
 
-    if (milestones.length === 1) {
+    if (deadline) {
       const selectedDeadline =
         deadline ?? milestoneDeadlines.find((d) => d.id === milestoneId);
 

--- a/components/tables/AllTeamsMilestoneTable/MilestoneSummary/MilestoneSummary.tsx
+++ b/components/tables/AllTeamsMilestoneTable/MilestoneSummary/MilestoneSummary.tsx
@@ -27,10 +27,11 @@ const MilestoneSummary: FC<Props> = ({
       total = 0;
 
     if (milestones.length === 1) {
-      const deadline = milestoneDeadlines.find((d) => d.id === milestoneId);
+      const selectedDeadline =
+        deadline ?? milestoneDeadlines.find((d) => d.id === milestoneId);
 
       submissions.forEach((sub) => {
-        if (sub.id !== milestoneId) {
+        if (!sub.id || !sub.updatedAt) {
           notSubmitted++;
           return;
         }
@@ -39,7 +40,7 @@ const MilestoneSummary: FC<Props> = ({
           submissionId: sub.id,
           isDraft: false,
           updatedAt: sub.updatedAt,
-          dueBy: deadline ? deadline.dueBy : "",
+          dueBy: selectedDeadline ? selectedDeadline.dueBy : "",
         });
 
         if (status === STATUS.SUBMITTED) {
@@ -114,7 +115,9 @@ const MilestoneSummary: FC<Props> = ({
       {milestones.map((milestone) => {
         const stats = countStatuses(milestone.id);
         const submissionRate =
-          ((stats.submitted + stats.submittedLate) / stats.total) * 100;
+          stats.total === 0
+            ? 0
+            : ((stats.submitted + stats.submittedLate) / stats.total) * 100;
 
         return (
           <Grid item xs={12} sm={6} md={4} key={milestone.id}>


### PR DESCRIPTION
## Description

This PR fixes the issue of displaying the correct submitted numbers in the summary card of the `All Team's Milestone Submissions` tab of the Admin Dashboard. 

<img width="1467" height="799" alt="image" src="https://github.com/user-attachments/assets/135ef28b-670e-4c86-8b81-9a67fe7750a4" />
