### PR TITLE
fix: fix csv display for admin dashboard

### DIFF
--- a/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.test.ts
+++ b/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "@jest/globals";
 
 import { DEADLINE_TYPE, Deadline } from "@/types/deadlines";
 import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
-import { PossibleSubmission } from "@/types/submissions";
 import { mapData } from "./ActionRow.helpers";
 
 const liftOffDeadline: Deadline = {

--- a/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.test.ts
+++ b/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable no-undef */
+import { describe, expect, it } from "@jest/globals";
+
+import { DEADLINE_TYPE, Deadline } from "@/types/deadlines";
+import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
+import { PossibleSubmission } from "@/types/submissions";
+import { mapData } from "./ActionRow.helpers";
+
+const liftOffDeadline: Deadline = {
+  id: 31,
+  cohortYear: 2026,
+  name: "Lift-Off Submission",
+  dueBy: "2026-05-18T16:00:00.000Z",
+  type: DEADLINE_TYPE.MILESTONE,
+  createdAt: "2026-05-01T00:00:00.000Z",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+const project = {
+  id: 6603,
+  name: "Amazing Project",
+  teamName: "Team Amaze",
+  proposalPdf: "",
+  videoUrl: "",
+  posterUrl: "",
+  students: [
+    {
+      id: 1,
+      studentId: 1,
+      name: "Leong Yi Quan",
+      email: "student-one@example.com",
+      cohortYear: 2026,
+      projectId: 6603,
+      nusnetId: "e0000001",
+      matricNo: "A0000001A",
+    },
+    {
+      id: 2,
+      studentId: 2,
+      name: "Chen Ye Kai Trevor",
+      email: "student-two@example.com",
+      cohortYear: 2026,
+      projectId: 6603,
+      nusnetId: "e0000002",
+      matricNo: "A0000002A",
+    },
+  ],
+  achievement: LEVELS_OF_ACHIEVEMENT.GEMINI,
+  cohortYear: 2026,
+  hasDropped: false,
+};
+
+describe("mapData", () => {
+  it("uses nested submissions for a single-milestone all export", () => {
+    const [result] = mapData(
+      [
+        {
+          deadline: liftOffDeadline,
+          fromProject: project,
+          submission: [
+            {
+              id: 9001,
+              deadline: liftOffDeadline,
+              deadlineId: liftOffDeadline.id,
+              updatedAt: "2026-05-18T14:38:00.000Z",
+              isDraft: false,
+              answers: [],
+              sections: [],
+            },
+          ],
+        },
+      ],
+      [liftOffDeadline],
+      false
+    );
+
+    expect(result).toMatchObject({
+      "Project Id": 6603,
+      "Project Name": "Amazing Project",
+      "Team Name": "Team Amaze",
+      "Lift-Off Submission Submission Updated At": "2026-05-18T14:38:00.000Z",
+      "Lift-Off Submission Status": "SUBMITTED",
+    });
+  });
+
+  it("uses top-level submission fields for a selected milestone export", () => {
+    const [result] = mapData(
+      [
+        {
+          deadline: liftOffDeadline,
+          id: 9001,
+          updatedAt: "2026-05-18T17:00:00.000Z",
+          fromProject: project,
+        },
+      ],
+      [liftOffDeadline],
+      true
+    );
+
+    expect(result).toMatchObject({
+      "Project Id": 6603,
+      "Project Name": "Amazing Project",
+      "Team Name": "Team Amaze",
+      "Lift-Off Submission Submission Updated At": "2026-05-18T17:00:00.000Z",
+      "Lift-Off Submission Status": "SUBMITTED_LATE",
+    });
+  });
+});

--- a/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.ts
+++ b/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.helpers.ts
@@ -23,7 +23,8 @@ const getStatusText = (status: STATUS): string => {
 
 export const mapData = (
   submissions: PossibleSubmission[],
-  csvMilestones: Deadline[]
+  csvMilestones: Deadline[],
+  isSelectedMilestoneExport = false
 ) => {
   return submissions.map((submission) => {
     const students = submission.fromProject?.students ?? [];
@@ -41,7 +42,7 @@ export const mapData = (
       "Student 2 Email": students[1]?.email ?? "",
     };
 
-    if (csvMilestones.length === 1) {
+    if (isSelectedMilestoneExport) {
       const selectedMilestoneDeadline = csvMilestones[0];
       const submissionStatus = generateSubmissionStatus({
         submissionId: submission.id,

--- a/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.tsx
+++ b/components/tables/AllTeamsMilestoneTable/ActionRow/ActionRow.tsx
@@ -92,7 +92,11 @@ const ActionRow: FC<Props> = ({
       const csvMilestones = selectedMilestoneDeadline
         ? [selectedMilestoneDeadline]
         : milestoneDeadlines;
-      const mappedData = mapData(data.submissions, csvMilestones);
+      const mappedData = mapData(
+        data.submissions,
+        csvMilestones,
+        Boolean(selectedMilestoneDeadline)
+      );
       setCsvData(mappedData);
     } catch (error) {
       setError(error);

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
@@ -134,10 +134,11 @@ const adviserEvaluation = {
 };
 
 describe("mapEvaluationData", () => {
-  it("maps adviser exports with evaluator and evaluatee details", () => {
+  it("uses nested submissions for a single-evaluation all export", () => {
     const [result] = mapEvaluationData(
       [adviserEvaluation],
-      [adviserEvaluationDeadline]
+      [adviserEvaluationDeadline],
+      false
     );
 
     expect(result).toMatchObject({
@@ -149,6 +150,27 @@ describe("mapEvaluationData", () => {
       "Evaluatee Team": "Team Atlas",
       "Evaluatee Student 1": "Alice",
       "Evaluatee Student 2": "Bob",
+      "Adviser Feedback Review Status": "SUBMITTED_LATE",
+    });
+  });
+
+  it("uses the selected evaluation submission for a selected evaluation export", () => {
+    const [result] = mapEvaluationData(
+      [
+        {
+          ...adviserEvaluation,
+          submission: adviserEvaluation.submission[0],
+        },
+      ],
+      [adviserEvaluationDeadline],
+      true
+    );
+
+    expect(result).toMatchObject({
+      "Relation ID": "A-102",
+      "Evaluator Type": "Adviser",
+      "Adviser Feedback Review Submission Updated At":
+        "2026-03-08T10:00:00.000Z",
       "Adviser Feedback Review Status": "SUBMITTED_LATE",
     });
   });

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
@@ -15,7 +15,8 @@ const getStatusText = (status: STATUS): string => {
 
 export const mapEvaluationData = (
   evaluations: PossibleSubmission[],
-  csvEvaluations: Deadline[]
+  csvEvaluations: Deadline[],
+  isSelectedEvaluationExport = false
 ) => {
   return evaluations.map((res) => {
     const evaluatorProject = res.fromProject;
@@ -56,7 +57,7 @@ export const mapEvaluationData = (
       "Evaluatee Student 2": evaluateeStudents[1]?.name ?? "",
     };
 
-    if (csvEvaluations.length === 1) {
+    if (isSelectedEvaluationExport) {
       const selectedEvaluationDeadline = csvEvaluations[0];
       const sub = Array.isArray(res.submission)
         ? res.submission[0]

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
@@ -54,8 +54,16 @@ jest.mock("react-csv", () => ({
 }));
 
 jest.mock("./EvaluationsActionRow.helpers", () => ({
-  mapEvaluationData: (evaluations: unknown[], csvEvaluations: unknown[]) =>
-    mockMapEvaluationData(evaluations, csvEvaluations),
+  mapEvaluationData: (
+    evaluations: unknown[],
+    csvEvaluations: unknown[],
+    isSelectedEvaluationExport: boolean
+  ) =>
+    mockMapEvaluationData(
+      evaluations,
+      csvEvaluations,
+      isSelectedEvaluationExport
+    ),
 }));
 
 jest.mock("@/helpers/api", () => ({
@@ -192,7 +200,8 @@ describe("EvaluationsActionRow", () => {
     await waitFor(() => {
       expect(mockMapEvaluationData).toHaveBeenCalledWith(
         [{ relationId: 1 }],
-        [evaluationOne]
+        [evaluationOne],
+        true
       );
     });
 

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
@@ -104,7 +104,11 @@ const EvaluationsActionRow: FC<Props> = ({
       const csvEvaluations = selectedEvaluationsDeadline
         ? [selectedEvaluationsDeadline]
         : evaluationsDeadlines;
-      const mappedData = mapEvaluationData(data.submissions, csvEvaluations);
+      const mappedData = mapEvaluationData(
+        data.submissions,
+        csvEvaluations,
+        Boolean(selectedEvaluationsDeadline)
+      );
       setCsvData(mappedData);
     } catch (error) {
       setError(error);

--- a/helpers/submissions.ts
+++ b/helpers/submissions.ts
@@ -24,7 +24,7 @@ export const generateSubmissionStatus = ({
   }
   const updatedAtDate = new Date(updatedAt);
   const dueByDate = new Date(dueBy);
-  if (updatedAtDate < dueByDate) {
+  if (updatedAtDate <= dueByDate) {
     return STATUS.SUBMITTED;
   } else {
     return STATUS.SUBMITTED_LATE;

--- a/pages/dashboard/administrator.tsx
+++ b/pages/dashboard/administrator.tsx
@@ -129,6 +129,7 @@ const AdministratorDashboard: NextPage = () => {
       search: querySearch,
       limit: LIMIT,
       submissionStatus:
+        !selectedMilestoneDeadline ||
         selectedSubmissionStatus === SUBMISSION_STATUS.ALL
           ? undefined
           : selectedSubmissionStatus,
@@ -153,6 +154,7 @@ const AdministratorDashboard: NextPage = () => {
       search: querySearch,
       limit: LIMIT,
       submissionStatus:
+        !selectedEvaluationsDeadline ||
         selectedSubmissionStatus === SUBMISSION_STATUS.ALL
           ? undefined
           : selectedSubmissionStatus,
@@ -178,6 +180,7 @@ const AdministratorDashboard: NextPage = () => {
         : undefined,
       search: querySearch,
       submissionStatus:
+        !selectedMilestoneDeadline ||
         selectedSubmissionStatus === SUBMISSION_STATUS.ALL
           ? undefined
           : selectedSubmissionStatus,
@@ -201,6 +204,7 @@ const AdministratorDashboard: NextPage = () => {
         : undefined,
       search: querySearch,
       submissionStatus:
+        !selectedEvaluationsDeadline ||
         selectedSubmissionStatus === SUBMISSION_STATUS.ALL
           ? undefined
           : selectedSubmissionStatus,


### PR DESCRIPTION
## Context

Previously, for cases with only one milestone in the system, there is a bug that causes the csv export to output `NOT_SUBMITTED` for all teams regardless of their true submission.

## Description

- fixed the bug causing the csv export (through parsing the state of filter - if it is a selected-deadline export)
- send `submissionStatus` only when the specific milestone / evaluations is selected to prevent stale filters
- add testcases for the modifications made