### PR TITLE
Fix public gallery CI SSG build

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -25,6 +25,8 @@ jobs:
       # Run Build
       - name: Build
         run: npm run build
+        env:
+          PUBLIC_GALLERY_SSG_OFFLINE: "true"
 
       # Run ESLint
       - name: ESLint Check

--- a/__tests__/pages/public-gallery-page.ssg.test.ts
+++ b/__tests__/pages/public-gallery-page.ssg.test.ts
@@ -28,6 +28,8 @@ jest.mock("@/ssg/config/ssg", () => ({
   PUBLIC_GALLERY_BUILD_PAGE_SIZE: 100,
   DEFAULT_PAGE: 1,
   getApiUrl: () => "http://localhost:4000/api",
+  isPublicGallerySsgOffline: () =>
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE === "true",
 }));
 
 const mockFetchPublicProjectCohortsFn = jest.fn();
@@ -50,7 +52,12 @@ import {
 import { getStaticProps as getIndexStaticProps } from "../../pages/public-gallery";
 
 beforeEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
   jest.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
 });
 
 describe("getStaticPaths", () => {
@@ -101,6 +108,19 @@ describe("getStaticPaths", () => {
     );
 
     await expect(getStaticPaths({})).rejects.toThrow("Connection refused");
+  });
+
+  it("returns no paths in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchPublicProjectCohortsFn).not.toHaveBeenCalled();
+    expect(mockFetchPublicProjectsCountFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      paths: [],
+      fallback: false,
+    });
   });
 });
 
@@ -270,6 +290,20 @@ describe("index getStaticProps", () => {
 
     const result = await getIndexStaticProps({} as any);
 
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        galleryProps: null,
+      },
+    });
+  });
+
+  it("renders a static empty state in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectCohortsFn).not.toHaveBeenCalled();
     expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
     expect(result).toEqual({
       props: {

--- a/__tests__/pages/public-gallery-projectId.ssg.test.ts
+++ b/__tests__/pages/public-gallery-projectId.ssg.test.ts
@@ -79,6 +79,8 @@ jest.mock("@/ssg/config/ssg", () => ({
   PAGE_SIZE: 28,
   DEFAULT_PAGE: 1,
   getApiUrl: () => "http://localhost:4000/api",
+  isPublicGallerySsgOffline: () =>
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE === "true",
 }));
 
 import {
@@ -88,8 +90,13 @@ import {
 import { ApiError } from "@/lib/api/projectsApi";
 
 beforeEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => null);
+});
+
+afterEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
 });
 
 describe("getStaticPaths", () => {
@@ -126,6 +133,18 @@ describe("getStaticPaths", () => {
     const result = await getStaticPaths({});
 
     expect(result.paths).toEqual([]);
+  });
+
+  it("returns empty paths in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchAllPublicProjectIds).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      paths: [],
+      fallback: false,
+    });
   });
 
   it("logs error with context on ApiError", async () => {

--- a/components/cards/ImageCard/ImageCard.cy.tsx
+++ b/components/cards/ImageCard/ImageCard.cy.tsx
@@ -1,15 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import ImageCard from "@/components/cards/ImageCard/ImageCard";
+import { noImageAvailableSrc } from "@/helpers/errors";
 import { getThumbnailUrl } from "@/helpers/images";
 import { mount } from "cypress/react18";
 
 describe("<ImageCard />", () => {
+  const triggerImageError = () => {
+    cy.get("img").then(($img) => {
+      $img[0].dispatchEvent(new Event("error"));
+    });
+  };
+
   let cardProps: {
     id: string;
     idDisplay: string;
     title: string;
-    imageSrc: string;
+    imageSrc?: string;
     actionButton?: React.ReactNode;
     extraContent?: React.ReactNode;
     onCardClick?: () => void;
@@ -22,7 +29,7 @@ describe("<ImageCard />", () => {
       id: "test-card-id",
       idDisplay: "1",
       title: "Test Card Title",
-      imageSrc: "/images/no-image-available.png",
+      imageSrc: "https://example.com/poster.jpg",
       actionButton: <button>Action</button>,
       extraContent: <div>Extra Content</div>,
       onCardClick: cy.stub().as("cardClick"),
@@ -41,6 +48,32 @@ describe("<ImageCard />", () => {
     cy.get("img").should("have.attr", "src", expectedThumb);
     cy.get("img").should("have.attr", "alt", cardProps.imgAlt);
     cy.contains("Extra Content").should("be.visible");
+  });
+
+  it("should fall back to the original image when the thumbnail proxy fails", () => {
+    mount(<ImageCard {...cardProps} />);
+
+    triggerImageError();
+
+    cy.get("img").should("have.attr", "src", cardProps.imageSrc);
+  });
+
+  it("should fall back to the default image when the original image also fails", () => {
+    mount(<ImageCard {...cardProps} />);
+
+    triggerImageError();
+    triggerImageError();
+
+    cy.get("img").should("have.attr", "src", noImageAvailableSrc);
+  });
+
+  it("should render the default image when no image source is provided", () => {
+    const propsWithoutImage = { ...cardProps };
+    delete propsWithoutImage.imageSrc;
+
+    mount(<ImageCard {...propsWithoutImage} />);
+
+    cy.get("img").should("have.attr", "src", noImageAvailableSrc);
   });
 
   it("should render action button correctly", () => {

--- a/components/cards/ImageCard/ImageCard.tsx
+++ b/components/cards/ImageCard/ImageCard.tsx
@@ -2,7 +2,7 @@ import { noImageAvailableSrc } from "@/helpers/errors";
 import { getThumbnailUrl } from "@/helpers/images";
 import { A4_ASPECT_RATIO, BASE_TRANSITION } from "@/styles/constants";
 import { Card, CardContent, Stack, Typography } from "@mui/material";
-import React, { FC } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 
 type Props = {
   id: string;
@@ -31,7 +31,34 @@ const ImageCard: FC<Props> = ({
   hoverEffect = true,
   priority = false,
 }) => {
-  const thumbnailUrl = getThumbnailUrl(imageSrc, 500, 20);
+  const thumbnailUrl = useMemo(
+    () => getThumbnailUrl(imageSrc, 500, 20),
+    [imageSrc]
+  );
+  const [currentImageSrc, setCurrentImageSrc] = useState(
+    thumbnailUrl || noImageAvailableSrc
+  );
+  const [fallbackStage, setFallbackStage] = useState<
+    "thumbnail" | "original" | "default"
+  >(thumbnailUrl ? "thumbnail" : "default");
+
+  useEffect(() => {
+    setCurrentImageSrc(thumbnailUrl || noImageAvailableSrc);
+    setFallbackStage(thumbnailUrl ? "thumbnail" : "default");
+  }, [thumbnailUrl]);
+
+  const handleImageError = () => {
+    if (fallbackStage === "thumbnail" && imageSrc) {
+      setCurrentImageSrc(imageSrc);
+      setFallbackStage("original");
+      return;
+    }
+
+    if (fallbackStage !== "default") {
+      setCurrentImageSrc(noImageAvailableSrc);
+      setFallbackStage("default");
+    }
+  };
 
   return (
     <Card
@@ -107,9 +134,10 @@ const ImageCard: FC<Props> = ({
             }}
           >
             <img
-              src={thumbnailUrl ?? noImageAvailableSrc}
+              src={currentImageSrc}
               alt={imgAlt}
               loading={priority ? "eager" : "lazy"}
+              onError={handleImageError}
               {...{ fetchpriority: priority ? "high" : "low" }}
               style={{
                 width: "100%",

--- a/pages/public-gallery/index.tsx
+++ b/pages/public-gallery/index.tsx
@@ -6,6 +6,7 @@ import CustomHead from "@/components/layout/CustomHead";
 import PublicGalleryPage from "@/components/publicGallery/PublicGalleryPage";
 import { PublicGalleryPageProps } from "@/helpers/publicGallery";
 import { fetchPublicProjectCohorts } from "@/lib/api/projectsApi";
+import { isPublicGallerySsgOffline } from "@/ssg/config/ssg";
 import { buildPublicGalleryPageProps } from "@/ssg/publicGallery";
 
 type Props = {
@@ -39,6 +40,14 @@ const PublicGalleryIndex: NextPage<Props> = ({ galleryProps }) => {
 };
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return {
+      props: {
+        galleryProps: null,
+      },
+    };
+  }
+
   const cohortYears = await fetchPublicProjectCohorts();
   const latestCohortYear = cohortYears[0];
 

--- a/pages/public-gallery/projects/[projectId].tsx
+++ b/pages/public-gallery/projects/[projectId].tsx
@@ -14,7 +14,10 @@ import GoBackButton from "@/components/buttons/GoBackButton";
 import Body from "@/components/layout/Body";
 import { Project } from "@/types/projects";
 import { noImageAvailableSrc } from "@/helpers/errors";
-import { PROJECT_PATHS_PAGE_SIZE } from "@/ssg/config/ssg";
+import {
+  isPublicGallerySsgOffline,
+  PROJECT_PATHS_PAGE_SIZE,
+} from "@/ssg/config/ssg";
 import {
   fetchAllPublicProjectIds,
   fetchProjectById,
@@ -148,6 +151,13 @@ const PublicProjectDetail: NextPage<Props> = ({ project }) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+
   try {
     // Use helper function to fetch all project IDs (SRP principle)
     const projectIds = await fetchAllPublicProjectIds(PROJECT_PATHS_PAGE_SIZE);

--- a/ssg/config/ssg.ts
+++ b/ssg/config/ssg.ts
@@ -37,3 +37,11 @@ export const getApiUrl = (): string => {
     process.env.NEXT_PUBLIC_BASE_DEV_API_URL || "http://localhost:4000/api"
   );
 };
+
+/**
+ * Allows frontend-only CI builds to complete without a backend SSG data source.
+ * Production-style builds should leave this unset so missing backend data fails fast.
+ */
+export const isPublicGallerySsgOffline = (): boolean => {
+  return process.env.PUBLIC_GALLERY_SSG_OFFLINE === "true";
+};

--- a/ssg/publicGallery.ts
+++ b/ssg/publicGallery.ts
@@ -1,6 +1,10 @@
 import { GetStaticPropsResult } from "next";
 import { PublicGalleryPageProps, slugToLevel } from "@/helpers/publicGallery";
-import { PAGE_SIZE, PUBLIC_GALLERY_BUILD_PAGE_SIZE } from "@/ssg/config/ssg";
+import {
+  isPublicGallerySsgOffline,
+  PAGE_SIZE,
+  PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+} from "@/ssg/config/ssg";
 import {
   fetchPublicProjectCohorts,
   fetchPublicProjects,
@@ -16,6 +20,10 @@ type BuildPublicGalleryPagePropsParams = {
 };
 
 export const getPublicGalleryStaticPaths = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return [];
+  }
+
   const cohortYears = await fetchPublicProjectCohorts();
   const levels = Object.values(LEVELS_OF_ACHIEVEMENT).map((l) =>
     l.toLowerCase()


### PR DESCRIPTION
Summary

This PR fixes the frontend CI SSG build by adding an explicit offline mode for public gallery static generation, so GitHub Actions can build the frontend without requiring a running backend. It also keeps the poster fallback fix for blank gallery cards.

Changes

Frontend CI / SSG:

- Add PUBLIC_GALLERY_SSG_OFFLINE=true as a build-time-only flag.
- Add isPublicGallerySsgOffline() to centralize the offline SSG check.
- Update public gallery SSG path generation to skip backend calls when offline mode is enabled.
- Update /public-gallery index SSG to render the static empty state in offline mode.
- Update /public-gallery/projects/[projectId] SSG path generation to skip backend calls in offline mode.
- Set PUBLIC_GALLERY_SSG_OFFLINE=true for the GitHub Actions npm run build step.
- Preserve normal local/staging/production behavior: without the flag, SSG still fetches real backend data and fails fast when required backend data is unavailable.

Gallery images:

- Update ImageCard to load the proxied thumbnail first.
- Fall back to the raw poster URL if the proxy image fails.
- Fall back to /images/no-image-available.png if the raw poster also fails or is missing.
- Reset fallback state when imageSrc changes.
- Preserve existing click behavior, which opens the raw poster URL when available.

Testing:
- npm test -- --runTestsByPath __tests__/pages/public-gallery-page.ssg.test.ts __tests__/pages/public-gallery-projectId.ssg.test.ts --runInBand

- PUBLIC_GALLERY_SSG_OFFLINE=true npm run build

Note: Offline SSG mode is only enabled in frontend CI. Production-style builds continue to use backend data.