### PR TITLE
feat: add project id into the collated responses dashboard

### DIFF
--- a/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.cy.tsx
+++ b/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.cy.tsx
@@ -221,7 +221,9 @@ describe("<CollatedMilestoneResponsesTable />", () => {
     mount(<CollatedMilestoneResponsesTable {...buildProps()} />);
 
     cy.get("thead").contains("Team Name").should("be.visible");
+    cy.get("thead").contains("Project Id").should("be.visible");
     cy.get("thead").contains("Project Name").should("be.visible");
+    cy.get("tbody").contains("101").should("be.visible");
     cy.get("tbody").contains("Team Atlas").should("be.visible");
     cy.get("tbody").contains("Atlas").should("be.visible");
     cy.get("tbody")
@@ -279,6 +281,7 @@ describe("<CollatedMilestoneResponsesTable />", () => {
         cy.get(`input[id="${inputId}"]`).should("be.disabled");
       });
     cy.get("thead").contains("Response").should("be.visible");
+    cy.get("thead").contains("Project Id").should("not.exist");
     cy.get("thead").contains("Team Name").should("not.exist");
     cy.get("thead").contains("Project Name").should("not.exist");
     cy.get("tbody").contains("Response 1").should("be.visible");

--- a/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.tsx
+++ b/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.tsx
@@ -506,8 +506,9 @@ const CollatedMilestoneResponsesTable: FC<Props> = ({
         if (viewAnonymousAnswers) {
           csvRow.response = `Response ${index + 1}`;
         } else {
-          csvRow.teamName = row.teamName;
-          csvRow.projectName = row.projectName;
+          csvRow["Project Id"] = row.projectId;
+          csvRow["Team Name"] = row.teamName;
+          csvRow["Project Name"] = row.projectName;
         }
 
         milestoneColumns.forEach(({ key, deadlineName, question }) => {
@@ -965,6 +966,7 @@ const CollatedMilestoneResponsesTable: FC<Props> = ({
                   <TableCell>Response</TableCell>
                 ) : (
                   <>
+                    <TableCell>Project Id</TableCell>
                     <TableCell>Team Name</TableCell>
                     <TableCell>Project Name</TableCell>
                   </>
@@ -1020,6 +1022,7 @@ const CollatedMilestoneResponsesTable: FC<Props> = ({
                     <TableCell>{`Response ${index + 1}`}</TableCell>
                   ) : (
                     <>
+                      <TableCell>{row.projectId}</TableCell>
                       <TableCell>{row.teamName}</TableCell>
                       <TableCell>{row.projectName}</TableCell>
                     </>

--- a/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.tsx
+++ b/components/tables/CollatedMilestoneResponsesTable/CollatedMilestoneResponsesTable.tsx
@@ -499,8 +499,8 @@ const CollatedMilestoneResponsesTable: FC<Props> = ({
     setCsvData(
       displayRows.map((row, index) => {
         const csvRow: Record<string, string | number> = {
-          milestoneId: row.milestoneId,
-          milestoneName: row.milestoneName,
+          "Milestone Id": row.milestoneId,
+          "Milestone Name": row.milestoneName,
         };
 
         if (viewAnonymousAnswers) {


### PR DESCRIPTION
## Description

The `Project Id` is missing from the panel and the exported CSV, which makes processing slightly more difficult. As such, this PR aims to add Project Id to the dashboard and the exported CSV for better view. 