### PR TITLE
fix: fix missing hoverlink for teams in evaluations tab

### DIFF
--- a/components/modals/EditDeadlineModal/EditDeadlineModal.tsx
+++ b/components/modals/EditDeadlineModal/EditDeadlineModal.tsx
@@ -116,6 +116,7 @@ const EditDeadlineModal: FC<Props> = ({
       >
         <Formik
           initialValues={initialValues}
+          enableReinitialize
           onSubmit={handleSubmit}
           validationSchema={editDeadlineValidationSchema}
         >

--- a/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.cy.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.cy.tsx
@@ -124,6 +124,8 @@ describe("<EvaluationsRow />", () => {
     cy.contains("td", "Adviser").should("be.visible");
     cy.contains("Prof Oak").should("be.visible");
     cy.contains("td", "N/A").should("be.visible");
-    cy.contains("Submitted late").should("be.visible");
+    cy.contains("a", "Submitted late")
+      .should("be.visible")
+      .and("have.attr", "href", "/submissions/601");
   });
 });

--- a/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.test.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.test.tsx
@@ -150,8 +150,9 @@ describe("EvaluationsRow", () => {
     expect(evaluatorLink.getAttribute("href")).toBe("/users/301");
 
     expect(screen.getByText("N/A")).toBeTruthy();
-    expect(
-      screen.getByText("Submitted late on 16 Apr 2026, 10:00")
-    ).toBeTruthy();
+    const lateSubmissionLink = screen.getByRole("link", {
+      name: "Submitted late on 16 Apr 2026, 10:00",
+    });
+    expect(lateSubmissionLink.getAttribute("href")).toBe("/submissions/601");
   });
 });

--- a/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.tsx
@@ -70,9 +70,15 @@ const EvaluationsRow: FC<Props> = ({ data, evaluationDeadlines, deadline }) => {
         );
       case STATUS.SUBMITTED_LATE:
         return (
-          <Box component="span" sx={{ color: "error.main" }}>
-            Submitted late {dateOn}
-          </Box>
+          <HoverLink
+            href={`${PAGES.SUBMISSIONS}/${submissionId}`}
+            wrap={true}
+            variant="body2"
+          >
+            <Box component="span" sx={{ color: "error.main" }}>
+              Submitted late {dateOn}
+            </Box>
+          </HoverLink>
         );
       default:
         return "Error";

--- a/components/typography/HoverLink/HoverLink.tsx
+++ b/components/typography/HoverLink/HoverLink.tsx
@@ -26,6 +26,9 @@ const HoverLink: FC<Props> = ({ href, wrap, variant, children }) => {
         component="a"
         variant={variant}
         sx={{
+          color: "inherit",
+          display: "block",
+          textDecoration: "none",
           whiteSpace: wrap ? undefined : "nowrap",
           overflow: "hidden",
           textOverflow: "ellipsis",

--- a/components/typography/HoverLink/HoverLink.tsx
+++ b/components/typography/HoverLink/HoverLink.tsx
@@ -23,6 +23,7 @@ const HoverLink: FC<Props> = ({ href, wrap, variant, children }) => {
   return (
     <Link href={href} passHref>
       <Typography
+        component="a"
         variant={variant}
         sx={{
           whiteSpace: wrap ? undefined : "nowrap",


### PR DESCRIPTION
## Description

Similar to the previous issue #94, this PR fixes the issue of missing hoverlink for groups that submitted late in the evaluation tab (i.e. no link pointing to the corresponding team submission). 