### PR TITLE
Add cohort-aware public gallery SSG

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -25,6 +25,8 @@ jobs:
       # Run Build
       - name: Build
         run: npm run build
+        env:
+          PUBLIC_GALLERY_SSG_OFFLINE: "true"
 
       # Run ESLint
       - name: ESLint Check

--- a/__tests__/pages/public-gallery-page.ssg.test.ts
+++ b/__tests__/pages/public-gallery-page.ssg.test.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+/**
+ * Unit tests for cohort-aware SSG functions in
+ * pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
+ */
+
+jest.mock("@/components/cards/ProjectCard/ProjectCard", () => {
+  function MockProjectCard() {
+    return null;
+  }
+  MockProjectCard.displayName = "MockProjectCard";
+  return MockProjectCard;
+});
+jest.mock("@/components/layout/CustomHead", () => {
+  function MockCustomHead() {
+    return null;
+  }
+  MockCustomHead.displayName = "MockCustomHead";
+  return MockCustomHead;
+});
+jest.mock("@/styles/constants", () => ({}));
+
+jest.mock("@/ssg/config/ssg", () => ({
+  PAGE_SIZE: 28,
+  PUBLIC_GALLERY_BUILD_PAGE_SIZE: 100,
+  DEFAULT_PAGE: 1,
+  getApiUrl: () => "http://localhost:4000/api",
+  isPublicGallerySsgOffline: () =>
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE === "true",
+}));
+
+const mockFetchPublicProjectCohortsFn = jest.fn();
+const mockFetchPublicProjectsCountFn = jest.fn();
+const mockFetchPublicProjectsFn = jest.fn();
+
+jest.mock("@/lib/api/projectsApi", () => ({
+  __esModule: true,
+  fetchPublicProjectCohorts: (...args: any[]) =>
+    mockFetchPublicProjectCohortsFn(...args),
+  fetchPublicProjectsCount: (...args: any[]) =>
+    mockFetchPublicProjectsCountFn(...args),
+  fetchPublicProjects: (...args: any[]) => mockFetchPublicProjectsFn(...args),
+}));
+
+import {
+  getStaticPaths,
+  getStaticProps,
+} from "../../pages/public-gallery/[cohortYear]/[level]/page/[page]";
+import { getStaticProps as getIndexStaticProps } from "../../pages/public-gallery";
+
+beforeEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
+});
+
+describe("getStaticPaths", () => {
+  it("generates all paths for each public cohort, level, and page", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
+    mockFetchPublicProjectsCountFn.mockResolvedValue({
+      total: 336,
+      totalPages: 12,
+    });
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchPublicProjectCohortsFn).toHaveBeenCalledTimes(1);
+    expect(mockFetchPublicProjectsCountFn).toHaveBeenCalledTimes(8);
+    expect(mockFetchPublicProjectsCountFn).toHaveBeenCalledWith(
+      28,
+      "artemis",
+      2026
+    );
+    expect(result.paths).toContainEqual({
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
+    });
+    expect(result.paths).toContainEqual({
+      params: { cohortYear: "2025", level: "vostok", page: "12" },
+    });
+    expect(result.paths.length).toBe(96);
+    expect(result.fallback).toBe(false);
+  });
+
+  it("generates at least one page for empty cohort-level combinations", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
+    mockFetchPublicProjectsCountFn.mockResolvedValue({
+      total: 0,
+      totalPages: 0,
+    });
+
+    const result = await getStaticPaths({});
+
+    expect(result.paths.length).toBe(4);
+    expect(result.paths[0]).toEqual({
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
+    });
+  });
+
+  it("fails the build when cohort discovery fails", async () => {
+    mockFetchPublicProjectCohortsFn.mockRejectedValue(
+      new Error("Connection refused")
+    );
+
+    await expect(getStaticPaths({})).rejects.toThrow("Connection refused");
+  });
+
+  it("returns no paths in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchPublicProjectCohortsFn).not.toHaveBeenCalled();
+    expect(mockFetchPublicProjectsCountFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      paths: [],
+      fallback: false,
+    });
+  });
+});
+
+describe("getStaticProps", () => {
+  const page1Response = {
+    projects: [
+      {
+        id: 1,
+        name: "Project 1",
+        teamName: "Team 1",
+        achievement: "Artemis",
+        cohortYear: 2026,
+        hasDropped: false,
+      },
+    ],
+    total: 50,
+    page: 1,
+    pageSize: 100,
+    totalPages: 2,
+  };
+
+  const page2Response = {
+    projects: [
+      {
+        id: 2,
+        name: "Project 2",
+        teamName: "Team 2",
+        achievement: "Artemis",
+        cohortYear: 2026,
+        hasDropped: false,
+      },
+    ],
+    total: 50,
+    page: 2,
+    pageSize: 100,
+    totalPages: 2,
+  };
+
+  it("fetches backend-filtered projects for a cohort and level", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
+    mockFetchPublicProjectsFn
+      .mockResolvedValueOnce(page1Response)
+      .mockResolvedValueOnce(page2Response);
+
+    const result = await getStaticProps({
+      params: { cohortYear: "2026", level: "artemis", page: "1" },
+    } as any);
+
+    expect(mockFetchPublicProjectsFn).toHaveBeenCalledTimes(2);
+    expect(mockFetchPublicProjectsFn).toHaveBeenNthCalledWith(
+      1,
+      1,
+      100,
+      "Artemis",
+      2026
+    );
+    expect(mockFetchPublicProjectsFn).toHaveBeenNthCalledWith(
+      2,
+      2,
+      100,
+      "Artemis",
+      2026
+    );
+    expect(result).toEqual({
+      props: {
+        projects: [page1Response.projects[0], page2Response.projects[0]],
+        currentPage: 1,
+        totalPages: 2,
+        total: 50,
+        level: "artemis",
+        cohortYear: 2026,
+        cohortYears: [2026, 2025],
+      },
+    });
+  });
+
+  it("returns notFound when requested page exceeds cohort-level total pages", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
+    mockFetchPublicProjectsFn.mockResolvedValue({
+      ...page1Response,
+      totalPages: 2,
+    });
+
+    const result = await getStaticProps({
+      params: { cohortYear: "2026", level: "apollo", page: "5" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("returns notFound for invalid cohort year params", async () => {
+    const result = await getStaticProps({
+      params: { cohortYear: "invalid", level: "gemini", page: "1" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound for invalid page params", async () => {
+    const result = await getStaticProps({
+      params: { cohortYear: "2026", level: "gemini", page: "-1" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+  });
+
+  it("fails the build when public project fetching fails", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026]);
+    mockFetchPublicProjectsFn.mockRejectedValue(new Error("Backend down"));
+
+    await expect(
+      getStaticProps({
+        params: { cohortYear: "2026", level: "vostok", page: "1" },
+      } as any)
+    ).rejects.toThrow("Backend down");
+  });
+});
+
+describe("index getStaticProps", () => {
+  const project = {
+    id: 1,
+    name: "Project 1",
+    teamName: "Team 1",
+    achievement: "Artemis",
+    cohortYear: 2026,
+    hasDropped: false,
+  };
+
+  it("renders the latest cohort Artemis gallery as static props", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([2026, 2025]);
+    mockFetchPublicProjectsFn.mockResolvedValue({
+      projects: [project],
+      total: 1,
+      page: 1,
+      pageSize: 100,
+      totalPages: 1,
+    });
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectCohortsFn).toHaveBeenCalledTimes(1);
+    expect(mockFetchPublicProjectsFn).toHaveBeenCalledWith(
+      1,
+      100,
+      "Artemis",
+      2026
+    );
+    expect(result).toEqual({
+      props: {
+        galleryProps: {
+          projects: [project],
+          currentPage: 1,
+          totalPages: 1,
+          total: 1,
+          level: "artemis",
+          cohortYear: 2026,
+          cohortYears: [2026, 2025],
+        },
+      },
+    });
+  });
+
+  it("renders a static empty state when no public cohorts exist", async () => {
+    mockFetchPublicProjectCohortsFn.mockResolvedValue([]);
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        galleryProps: null,
+      },
+    });
+  });
+
+  it("renders a static empty state in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getIndexStaticProps({} as any);
+
+    expect(mockFetchPublicProjectCohortsFn).not.toHaveBeenCalled();
+    expect(mockFetchPublicProjectsFn).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        galleryProps: null,
+      },
+    });
+  });
+});

--- a/__tests__/pages/public-gallery-projectId.ssg.test.ts
+++ b/__tests__/pages/public-gallery-projectId.ssg.test.ts
@@ -1,0 +1,290 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+
+/**
+ * Unit tests for SSG functions in pages/public-gallery/projects/[projectId].tsx
+ *
+ * Tests getStaticPaths() and getStaticProps() for the individual project detail page:
+ * - getStaticPaths: fetches all public project IDs for path generation
+ * - getStaticProps: fetches single project data by ID
+ */
+
+// Mock React component dependencies to avoid import resolution issues
+// MUST mock Body before any component that imports it to prevent deep dependency resolution
+jest.mock("@/components/layout/Body", () => {
+  function MockBody({ children }: any) {
+    return children;
+  }
+  MockBody.displayName = "MockBody";
+  return {
+    __esModule: true,
+    default: MockBody,
+  };
+});
+
+jest.mock("@/components/layout/CustomHead", () => {
+  function MockCustomHead() {
+    return null;
+  }
+  MockCustomHead.displayName = "MockCustomHead";
+  return MockCustomHead;
+});
+jest.mock("@/components/typography/Attribute", () => {
+  function MockAttribute() {
+    return null;
+  }
+  MockAttribute.displayName = "MockAttribute";
+  return MockAttribute;
+});
+jest.mock("@/components/typography/UsersName", () => {
+  function MockUsersName() {
+    return null;
+  }
+  MockUsersName.displayName = "MockUsersName";
+  return MockUsersName;
+});
+jest.mock("@/helpers/errors", () => ({
+  getImageOrDefault: jest.fn((url: string) => url),
+}));
+jest.mock("@/styles/constants", () => ({}));
+
+// Mock the API module
+const mockFetchAllPublicProjectIds = jest.fn();
+const mockFetchProjectById = jest.fn();
+
+jest.mock("@/lib/api/projectsApi", () => {
+  class ApiError extends Error {
+    statusCode: number;
+    endpoint: string;
+    constructor(message: string, statusCode: number, endpoint: string) {
+      super(message);
+      this.name = "ApiError";
+      this.statusCode = statusCode;
+      this.endpoint = endpoint;
+    }
+  }
+  return {
+    __esModule: true,
+    fetchAllPublicProjectIds: (...args: any[]) =>
+      mockFetchAllPublicProjectIds(...args),
+    fetchProjectById: (...args: any[]) => mockFetchProjectById(...args),
+    ApiError,
+  };
+});
+
+// Mock SSG config
+jest.mock("@/ssg/config/ssg", () => ({
+  PROJECT_PATHS_PAGE_SIZE: 100,
+  PAGE_SIZE: 28,
+  DEFAULT_PAGE: 1,
+  getApiUrl: () => "http://localhost:4000/api",
+  isPublicGallerySsgOffline: () =>
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE === "true",
+}));
+
+import {
+  getStaticPaths,
+  getStaticProps,
+} from "../../pages/public-gallery/projects/[projectId]";
+import { ApiError } from "@/lib/api/projectsApi";
+
+beforeEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
+  jest.clearAllMocks();
+  jest.spyOn(console, "error").mockImplementation(() => null);
+});
+
+afterEach(() => {
+  delete process.env.PUBLIC_GALLERY_SSG_OFFLINE;
+});
+
+describe("getStaticPaths", () => {
+  it("generates paths for all public project IDs", async () => {
+    mockFetchAllPublicProjectIds.mockResolvedValue([1, 2, 3, 5, 10]);
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchAllPublicProjectIds).toHaveBeenCalledWith(100); // PROJECT_PATHS_PAGE_SIZE
+    expect(result.paths).toEqual([
+      { params: { projectId: "1" } },
+      { params: { projectId: "2" } },
+      { params: { projectId: "3" } },
+      { params: { projectId: "5" } },
+      { params: { projectId: "10" } },
+    ]);
+    expect(result.fallback).toBe(false);
+  });
+
+  it("returns empty paths when no public projects exist", async () => {
+    mockFetchAllPublicProjectIds.mockResolvedValue([]);
+
+    const result = await getStaticPaths({});
+
+    expect(result.paths).toEqual([]);
+    expect(result.fallback).toBe(false);
+  });
+
+  it("returns empty paths on API error", async () => {
+    mockFetchAllPublicProjectIds.mockRejectedValue(
+      new ApiError("Server Error", 500, "/projects/public")
+    );
+
+    const result = await getStaticPaths({});
+
+    expect(result.paths).toEqual([]);
+  });
+
+  it("returns empty paths in offline SSG mode without API calls", async () => {
+    process.env.PUBLIC_GALLERY_SSG_OFFLINE = "true";
+
+    const result = await getStaticPaths({});
+
+    expect(mockFetchAllPublicProjectIds).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      paths: [],
+      fallback: false,
+    });
+  });
+
+  it("logs error with context on ApiError", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error");
+    mockFetchAllPublicProjectIds.mockRejectedValue(
+      new ApiError("Server Error", 500, "/projects/public")
+    );
+
+    await getStaticPaths({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[SSG] Failed to fetch project paths:",
+      expect.stringContaining("API Error (500)")
+    );
+  });
+
+  it("logs error on unknown error", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error");
+    mockFetchAllPublicProjectIds.mockRejectedValue(
+      new Error("Network timeout")
+    );
+
+    await getStaticPaths({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[SSG] Failed to fetch project paths:",
+      expect.stringContaining("Unknown error")
+    );
+  });
+});
+
+describe("getStaticProps", () => {
+  const mockProject = {
+    id: 1,
+    name: "Test Project",
+    teamName: "Team Test",
+    achievement: "Artemis",
+    cohortYear: 2024,
+    hasDropped: false,
+    students: [],
+    adviser: null,
+    mentor: null,
+    posterUrl: "https://example.com/poster.jpg",
+    videoUrl: null,
+    proposalPdf: null,
+  };
+
+  it("fetches project by ID and returns props", async () => {
+    mockFetchProjectById.mockResolvedValue({ project: mockProject });
+
+    const result = await getStaticProps({
+      params: { projectId: "1" },
+    } as any);
+
+    expect(mockFetchProjectById).toHaveBeenCalledWith("1");
+    expect(result).toEqual({
+      props: {
+        project: mockProject,
+      },
+    });
+  });
+
+  it("returns notFound for dropped projects", async () => {
+    const droppedProject = { ...mockProject, hasDropped: true };
+    mockFetchProjectById.mockResolvedValue({ project: droppedProject });
+
+    const result = await getStaticProps({
+      params: { projectId: "6" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("returns notFound when project is missing or null", async () => {
+    mockFetchProjectById.mockResolvedValue({ project: null });
+
+    const result = await getStaticProps({
+      params: { projectId: "999" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("returns notFound on API error", async () => {
+    mockFetchProjectById.mockRejectedValue(
+      new ApiError("Not Found", 404, "/projects/999")
+    );
+
+    const result = await getStaticProps({
+      params: { projectId: "999" },
+    } as any);
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it("logs error with context on ApiError", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error");
+    mockFetchProjectById.mockRejectedValue(
+      new ApiError("Server Error", 500, "/projects/1")
+    );
+
+    await getStaticProps({ params: { projectId: "1" } } as any);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[SSG] Failed to fetch project 1"),
+      expect.stringContaining("API Error (500)")
+    );
+  });
+
+  it("logs error on unknown error", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error");
+    mockFetchProjectById.mockRejectedValue(new Error("Timeout"));
+
+    await getStaticProps({ params: { projectId: "42" } } as any);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[SSG] Failed to fetch project 42"),
+      expect.stringContaining("Unknown error")
+    );
+  });
+
+  it("preserves all project fields in props", async () => {
+    const fullProject = {
+      ...mockProject,
+      posterUrl: "https://example.com/poster.jpg",
+      videoUrl: "https://example.com/video",
+      proposalPdf: "https://example.com/proposal.pdf",
+      students: [
+        { id: 1, name: "Student One" },
+        { id: 2, name: "Student Two" },
+      ],
+      adviser: { adviserId: 1, name: "Adviser One" },
+      mentor: { mentorId: 1, name: "Mentor One" },
+    };
+    mockFetchProjectById.mockResolvedValue({ project: fullProject });
+
+    const result = await getStaticProps({
+      params: { projectId: "1" },
+    } as any);
+
+    expect((result as any).props.project).toEqual(fullProject);
+  });
+});

--- a/components/cards/ProjectCard/ProjectCard.tsx
+++ b/components/cards/ProjectCard/ProjectCard.tsx
@@ -12,10 +12,17 @@ import ImageCard from "@/components/cards/ImageCard/ImageCard";
 
 type Props = {
   project: Project;
-  priority: boolean;
+  priority?: boolean;
+  detailsLinkPath?: string;
 };
 
-const ProjectCard: FC<Props> = ({ project, priority = false }) => {
+const ProjectCard: FC<Props> = ({
+  project,
+  priority = false,
+  detailsLinkPath,
+}) => {
+  const detailsHref = detailsLinkPath || `${PAGES.PROJECTS}/${project.id}`;
+
   return (
     <ImageCard
       id={project.id.toString()}
@@ -53,7 +60,7 @@ const ProjectCard: FC<Props> = ({ project, priority = false }) => {
       }
       actionButton={
         <Stack direction={{ xs: "column-reverse", md: "row" }} gap="0.5rem">
-          <Link passHref href={`${PAGES.PROJECTS}/${project.id}`}>
+          <Link passHref href={detailsHref}>
             <Button
               variant="outlined"
               size="small"

--- a/components/publicGallery/PublicGalleryPage.tsx
+++ b/components/publicGallery/PublicGalleryPage.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useRef, useState, useEffect } from "react";
+import {
+  Box,
+  Container,
+  Grid,
+  Typography,
+  Pagination,
+  Tabs,
+  Tab,
+  tabsClasses,
+  Stack,
+  TextField,
+  MenuItem,
+} from "@mui/material";
+import { useRouter } from "next/router";
+import Fuse from "fuse.js";
+import ProjectCard from "@/components/cards/ProjectCard/ProjectCard";
+import CustomHead from "@/components/layout/CustomHead";
+import SearchInput from "@/components/search/SearchInput/SearchInput";
+import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
+import { PAGE_SIZE } from "@/ssg/config/ssg";
+import {
+  levelToSlug,
+  PublicGalleryPageProps,
+  slugToLevel,
+} from "@/helpers/publicGallery";
+
+const PublicGalleryPage = ({
+  projects,
+  currentPage,
+  level,
+  cohortYear,
+  cohortYears,
+}: PublicGalleryPageProps) => {
+  const router = useRouter();
+  const selectedLevel = slugToLevel(level);
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(projects, {
+        keys: [
+          "name",
+          "teamName",
+          "students.name",
+          "adviser.name",
+          "mentor.name",
+        ],
+        threshold: 0.3,
+        ignoreLocation: true,
+      }),
+    [projects]
+  );
+
+  const handleSearchChange = (value: string) => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+    searchTimeoutRef.current = setTimeout(() => {
+      setSearchQuery(value);
+    }, 200);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const searchedProjects = useMemo(() => {
+    if (!searchQuery.trim()) return projects;
+    return fuse.search(searchQuery).map((result) => result.item);
+  }, [fuse, searchQuery, projects]);
+
+  const searchedTotalPages = Math.max(
+    Math.ceil(searchedProjects.length / PAGE_SIZE),
+    1
+  );
+  const clientPage = Math.min(currentPage, searchedTotalPages);
+  const paginatedProjects = searchedProjects.slice(
+    (clientPage - 1) * PAGE_SIZE,
+    clientPage * PAGE_SIZE
+  );
+
+  const handleCohortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextCohortYear = Number(event.target.value);
+    router.push({
+      pathname: `/public-gallery/${nextCohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/1/`,
+    });
+  };
+
+  const handleTabChange = (
+    _: React.SyntheticEvent,
+    newLevel: LEVELS_OF_ACHIEVEMENT
+  ) => {
+    router.push({
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        newLevel
+      )}/page/1/`,
+    });
+  };
+
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    page: number
+  ) => {
+    router.push({
+      pathname: `/public-gallery/${cohortYear}/${levelToSlug(
+        selectedLevel
+      )}/page/${page}/`,
+    });
+  };
+
+  return (
+    <>
+      <CustomHead
+        title={`${cohortYear} ${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
+      />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box
+          sx={{
+            mb: 4,
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            justifyContent: "space-between",
+            alignItems: { sm: "center" },
+            gap: 2,
+          }}
+        >
+          <Box>
+            <Typography variant="h3" component="h1" gutterBottom>
+              Public Project Gallery
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Explore outstanding {selectedLevel} projects from the Orbital
+              program ({searchedProjects.length} projects in {cohortYear})
+            </Typography>
+          </Box>
+        </Box>
+
+        <Stack direction="column" spacing={2} sx={{ mb: 3 }}>
+          <Box
+            sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}
+          >
+            <SearchInput
+              id="project-search"
+              label="Search projects"
+              onChange={handleSearchChange}
+            />
+            <TextField
+              id="cohort-select"
+              name="cohort"
+              label="Cohort"
+              value={cohortYear}
+              onChange={handleCohortChange}
+              select
+              size="small"
+              sx={{ minWidth: 120 }}
+            >
+              {cohortYears.map((year) => (
+                <MenuItem key={year} value={year}>
+                  {year}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+          <Tabs
+            value={selectedLevel}
+            onChange={handleTabChange}
+            textColor="secondary"
+            indicatorColor="secondary"
+            aria-label="achievement-level-tabs"
+            variant="scrollable"
+            scrollButtons="auto"
+            allowScrollButtonsMobile
+            sx={{ [`& .${tabsClasses.scrollButtons}`]: { color: "primary" } }}
+          >
+            {Object.values(LEVELS_OF_ACHIEVEMENT).map((lvl) => (
+              <Tab key={lvl} value={lvl} label={lvl} />
+            ))}
+          </Tabs>
+        </Stack>
+
+        <Grid container spacing={3}>
+          {paginatedProjects.map((project) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={project.id}>
+              <ProjectCard
+                project={project}
+                detailsLinkPath={`/public-gallery/projects/${project.id}`}
+              />
+            </Grid>
+          ))}
+        </Grid>
+
+        {paginatedProjects.length === 0 && (
+          <Box sx={{ textAlign: "center", py: 8 }}>
+            <Typography variant="h6" color="text.secondary">
+              No projects found
+              {searchQuery ? ` matching "${searchQuery}"` : ""}
+              {` in ${cohortYear} for ${selectedLevel}`}
+            </Typography>
+          </Box>
+        )}
+
+        {searchedTotalPages > 1 && (
+          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+            <Pagination
+              count={searchedTotalPages}
+              page={clientPage}
+              onChange={handlePageChange}
+              color="primary"
+              size="large"
+              showFirstButton
+              showLastButton
+            />
+          </Box>
+        )}
+      </Container>
+    </>
+  );
+};
+
+export default PublicGalleryPage;

--- a/components/publicGallery/PublicGalleryPage.tsx
+++ b/components/publicGallery/PublicGalleryPage.tsx
@@ -17,6 +17,7 @@ import Fuse from "fuse.js";
 import ProjectCard from "@/components/cards/ProjectCard/ProjectCard";
 import CustomHead from "@/components/layout/CustomHead";
 import SearchInput from "@/components/search/SearchInput/SearchInput";
+import { NAVBAR_HEIGHT_REM } from "@/styles/constants";
 import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
 import { PAGE_SIZE } from "@/ssg/config/ssg";
 import {
@@ -121,7 +122,10 @@ const PublicGalleryPage = ({
       <CustomHead
         title={`${cohortYear} ${selectedLevel} Projects - Public Gallery - Page ${clientPage}`}
       />
-      <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Container
+        maxWidth="xl"
+        sx={{ pt: `calc(${NAVBAR_HEIGHT_REM} + 2rem)`, pb: 4 }}
+      >
         <Box
           sx={{
             mb: 4,

--- a/cypress/e2e/public-gallery/public-gallery.cy.js
+++ b/cypress/e2e/public-gallery/public-gallery.cy.js
@@ -1,0 +1,280 @@
+/* eslint-disable no-undef */
+
+/**
+ * E2E Tests for Public Gallery Static Site Generation Feature
+ *
+ * Test Plan Coverage:
+ * 1. Static page rendering and navigation
+ * 2. Pagination functionality
+ * 3. Achievement level tab filtering (Artemis, Apollo, Gemini, Vostok)
+ * 4. Cohort year dropdown routing
+ * 5. Project detail page navigation and content
+ * 6. Edge cases: empty states, 404 pages
+ */
+
+describe("Public Gallery - SSG Feature", () => {
+  const getSelectedCohortYear = () => {
+    return cy.get('input[name="cohort"]').invoke("val");
+  };
+
+  describe("Index Page", () => {
+    beforeEach(() => {
+      cy.visit("http://localhost:3000/public-gallery/");
+    });
+
+    it("renders the public gallery index page", () => {
+      cy.contains("h1", "Public Project Gallery").should("be.visible");
+      cy.contains("Explore outstanding").should("be.visible");
+    });
+
+    it("displays achievement level tabs", () => {
+      cy.get('[aria-label="achievement-level-tabs"]').should("be.visible");
+      cy.contains("button", "Artemis").should("be.visible");
+      cy.contains("button", "Apollo").should("be.visible");
+      cy.contains("button", "Gemini").should("be.visible");
+      cy.contains("button", "Vostok").should("be.visible");
+    });
+
+    it("has Artemis tab selected by default", () => {
+      cy.contains("button", "Artemis").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+    });
+
+    it("displays cohort year dropdown selector", () => {
+      cy.get("#cohort-select").should("be.visible");
+    });
+
+    it("filters projects when switching achievement tabs", () => {
+      // Click Apollo tab
+      cy.contains("button", "Apollo").click();
+      cy.contains("button", "Apollo").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+
+      // Click Gemini tab
+      cy.contains("button", "Gemini").click();
+      cy.contains("button", "Gemini").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+
+      // Click Vostok tab
+      cy.contains("button", "Vostok").click();
+      cy.contains("button", "Vostok").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+
+      // Return to Artemis tab
+      cy.contains("button", "Artemis").click();
+      cy.contains("button", "Artemis").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+    });
+
+    it("filters projects when changing cohort year", () => {
+      // Open the cohort selector dropdown
+      cy.get("#cohort-select").click();
+
+      // Select a cohort year from the dropdown (wait for menu to appear)
+      cy.get('[role="listbox"]').should("be.visible");
+      cy.get('[role="option"]').first().click();
+
+      // Verify the selection was made (dropdown closed)
+      cy.get('[role="listbox"]').should("not.exist");
+    });
+
+    it("shows empty state when no projects match filter", () => {
+      // This test verifies the empty state component renders
+      // The actual empty state depends on data availability
+      cy.get("body").then(($body) => {
+        if ($body.find('[data-testid="empty-state"]').length > 0) {
+          cy.contains("No projects available for").should("be.visible");
+        }
+      });
+    });
+  });
+
+  describe("Pagination", () => {
+    beforeEach(() => {
+      cy.visit("http://localhost:3000/public-gallery/");
+    });
+
+    it("displays pagination when multiple pages exist", () => {
+      // Check if pagination exists (depends on total project count)
+      cy.get("body").then(($body) => {
+        if ($body.find('nav[aria-label="pagination navigation"]').length > 0) {
+          cy.get('nav[aria-label="pagination navigation"]').should(
+            "be.visible"
+          );
+        }
+      });
+    });
+
+    it("navigates to page 2 when clicking pagination", () => {
+      cy.get("body").then(($body) => {
+        if ($body.find('nav[aria-label="pagination navigation"]').length > 0) {
+          // Click page 2 button
+          cy.get('button[aria-label="Go to page 2"]').click();
+          cy.url().should("include", "/artemis/page/2");
+        }
+      });
+    });
+  });
+
+  describe("Paginated Pages (/public-gallery/[cohortYear]/[level]/page/[page])", () => {
+    it("renders page 1", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      getSelectedCohortYear().then((cohortYear) => {
+        cy.visit(
+          `http://localhost:3000/public-gallery/${cohortYear}/artemis/page/1/`
+        );
+        cy.contains("h1", "Public Project Gallery").should("be.visible");
+      });
+    });
+
+    it("displays achievement tabs on paginated pages", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.get('[aria-label="achievement-level-tabs"]').should("be.visible");
+      cy.contains("button", "Artemis").should("be.visible");
+    });
+
+    it("displays cohort selector on paginated pages", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.get("#cohort-select").should("be.visible");
+    });
+
+    it("allows switching between achievement tabs", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.contains("button", "Apollo").click();
+      cy.contains("button", "Apollo").should(
+        "have.attr",
+        "aria-selected",
+        "true"
+      );
+      cy.location("pathname").should(
+        "match",
+        /\/public-gallery\/\d+\/apollo\/page\/1\//
+      );
+    });
+
+    it("returns 404 for pages beyond generated static pages", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      getSelectedCohortYear().then((cohortYear) => {
+        cy.request({
+          url: `http://localhost:3000/public-gallery/${cohortYear}/artemis/page/999/`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(404);
+        });
+      });
+    });
+  });
+
+  describe("Project Detail Pages", () => {
+    it("navigates to project detail page when clicking a project card", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      // Wait for projects to load and click first project card
+      cy.get("body").then(($body) => {
+        // Check if there are project cards
+        if (
+          $body.find('[class*="ProjectCard"]').length > 0 ||
+          $body.find('[class*="MuiCard"]').length > 0
+        ) {
+          cy.contains("a", "Details").first().click();
+          cy.url().should("include", "/public-gallery/projects/");
+        }
+      });
+    });
+
+    it("displays project details on detail page", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.get("body").then(($body) => {
+        if ($body.find('[class*="MuiCard"]').length > 0) {
+          cy.contains("a", "Details").first().click();
+
+          // Verify detail page elements
+          cy.get("#go-back-button").should("be.visible");
+          cy.contains("Project ID").should("be.visible");
+          cy.contains("Project Name").should("be.visible");
+          cy.contains("Level of Achievement").should("be.visible");
+        }
+      });
+    });
+
+    it("navigates back to gallery when clicking Back to Gallery button", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.get("body").then(($body) => {
+        if ($body.find('[class*="MuiCard"]').length > 0) {
+          cy.contains("a", "Details").first().click();
+          cy.url().should("include", "/public-gallery/projects/");
+
+          // Click back button
+          cy.get("#go-back-button").click();
+          cy.url().should("include", "/public-gallery");
+          cy.url().should("not.include", "/projects/");
+        }
+      });
+    });
+
+    it("returns 404 for non-existent project ID", () => {
+      cy.request({
+        url: "http://localhost:3000/public-gallery/projects/99999999/",
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(404);
+      });
+    });
+  });
+
+  describe("Data Integrity and Sorting", () => {
+    it("displays project count in header", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+      cy.contains("projects").should("be.visible");
+    });
+
+    it("projects are visible in the grid layout", () => {
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      // Verify grid container exists
+      cy.get(".MuiGrid-container").should("be.visible");
+    });
+  });
+
+  describe("Responsive Design", () => {
+    it("displays correctly on mobile viewport", () => {
+      cy.viewport("iphone-6");
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.contains("h1", "Public Project Gallery").should("be.visible");
+      cy.get('[aria-label="achievement-level-tabs"]').should("be.visible");
+    });
+
+    it("displays correctly on tablet viewport", () => {
+      cy.viewport("ipad-2");
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.contains("h1", "Public Project Gallery").should("be.visible");
+    });
+
+    it("displays correctly on desktop viewport", () => {
+      cy.viewport(1920, 1080);
+      cy.visit("http://localhost:3000/public-gallery/");
+
+      cy.contains("h1", "Public Project Gallery").should("be.visible");
+    });
+  });
+});

--- a/helpers/publicGallery.test.ts
+++ b/helpers/publicGallery.test.ts
@@ -1,0 +1,236 @@
+/* eslint-disable no-undef */
+import { describe, expect, it } from "@jest/globals";
+import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
+import {
+  filterProjects,
+  filterProjectsByLevel,
+  extractCohortYears,
+  getMostRecentCohort,
+} from "./publicGallery";
+import { DeepPartial } from "./types";
+
+/** Helper function to generate a mock project */
+const generateMockProject = (overrides: DeepPartial<Project> = {}): Project => {
+  return {
+    id: 1,
+    name: "Test Project",
+    teamName: "Test Team",
+    proposalPdf: "http://example.com/proposal.pdf",
+    videoUrl: "http://example.com/video",
+    posterUrl: "http://example.com/poster.jpg",
+    students: [],
+    achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+    cohortYear: 2024,
+    hasDropped: false,
+    ...overrides,
+  } as Project;
+};
+
+describe("Public Gallery Helpers", () => {
+  describe("#filterProjects", () => {
+    const mockProjects: Project[] = [
+      generateMockProject({
+        id: 1,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        cohortYear: 2024,
+      }),
+      generateMockProject({
+        id: 2,
+        achievement: LEVELS_OF_ACHIEVEMENT.APOLLO,
+        cohortYear: 2024,
+      }),
+      generateMockProject({
+        id: 3,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        cohortYear: 2023,
+      }),
+      generateMockProject({
+        id: 4,
+        achievement: LEVELS_OF_ACHIEVEMENT.GEMINI,
+        cohortYear: 2024,
+      }),
+      generateMockProject({
+        id: 5,
+        achievement: LEVELS_OF_ACHIEVEMENT.VOSTOK,
+        cohortYear: 2022,
+      }),
+      generateMockProject({
+        id: 6,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        cohortYear: 2024,
+        hasDropped: true,
+      }),
+    ];
+
+    it("filters by achievement level only when cohort is empty", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        ""
+      );
+      expect(result).toHaveLength(2);
+      expect(
+        result.every((p) => p.achievement === LEVELS_OF_ACHIEVEMENT.ARTEMIS)
+      ).toBe(true);
+    });
+
+    it("filters by both achievement level and cohort year", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        2024
+      );
+      expect(result).toMatchObject([{ id: 1 }]);
+    });
+
+    it("excludes dropped projects", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        2024
+      );
+      expect(result.some((p) => p.hasDropped)).toBe(false);
+    });
+
+    it("returns empty array when no projects match", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.VOSTOK,
+        2024
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it("handles empty projects array", () => {
+      const result = filterProjects([], LEVELS_OF_ACHIEVEMENT.ARTEMIS, 2024);
+      expect(result).toHaveLength(0);
+    });
+
+    it("filters Apollo projects correctly", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.APOLLO,
+        ""
+      );
+      expect(result).toMatchObject([{ id: 2 }]);
+    });
+
+    it("filters Gemini projects correctly", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.GEMINI,
+        2024
+      );
+      expect(result).toMatchObject([{ id: 4 }]);
+    });
+
+    it("filters Vostok projects correctly", () => {
+      const result = filterProjects(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.VOSTOK,
+        2022
+      );
+      expect(result).toMatchObject([{ id: 5 }]);
+    });
+  });
+
+  describe("#filterProjectsByLevel", () => {
+    const mockProjects: Project[] = [
+      generateMockProject({
+        id: 1,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        cohortYear: 2024,
+      }),
+      generateMockProject({
+        id: 2,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        cohortYear: 2023,
+      }),
+      generateMockProject({
+        id: 3,
+        achievement: LEVELS_OF_ACHIEVEMENT.APOLLO,
+        cohortYear: 2024,
+      }),
+      generateMockProject({
+        id: 4,
+        achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+        hasDropped: true,
+      }),
+    ];
+
+    it("filters by achievement level ignoring cohort", () => {
+      const result = filterProjectsByLevel(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.ARTEMIS
+      );
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.id)).toEqual([1, 2]);
+    });
+
+    it("excludes dropped projects", () => {
+      const result = filterProjectsByLevel(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.ARTEMIS
+      );
+      expect(result.some((p) => p.hasDropped)).toBe(false);
+    });
+
+    it("returns empty array when no projects match", () => {
+      const result = filterProjectsByLevel(
+        mockProjects,
+        LEVELS_OF_ACHIEVEMENT.GEMINI
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("#extractCohortYears", () => {
+    it("extracts unique years sorted descending", () => {
+      const projects: Project[] = [
+        generateMockProject({ cohortYear: 2022 }),
+        generateMockProject({ cohortYear: 2024 }),
+        generateMockProject({ cohortYear: 2023 }),
+        generateMockProject({ cohortYear: 2024 }),
+      ];
+      const result = extractCohortYears(projects);
+      expect(result).toEqual([2024, 2023, 2022]);
+    });
+
+    it("returns empty array for empty projects", () => {
+      const result = extractCohortYears([]);
+      expect(result).toEqual([]);
+    });
+
+    it("handles single cohort year", () => {
+      const projects: Project[] = [
+        generateMockProject({ cohortYear: 2024 }),
+        generateMockProject({ cohortYear: 2024 }),
+      ];
+      const result = extractCohortYears(projects);
+      expect(result).toEqual([2024]);
+    });
+  });
+
+  describe("#getMostRecentCohort", () => {
+    it("returns the most recent (highest) cohort year", () => {
+      const projects: Project[] = [
+        generateMockProject({ cohortYear: 2022 }),
+        generateMockProject({ cohortYear: 2024 }),
+        generateMockProject({ cohortYear: 2023 }),
+      ];
+      const result = getMostRecentCohort(projects);
+      expect(result).toBe(2024);
+    });
+
+    it("returns empty string for empty projects", () => {
+      const result = getMostRecentCohort([]);
+      expect(result).toBe("");
+    });
+
+    it("returns the only year when single project exists", () => {
+      const projects: Project[] = [generateMockProject({ cohortYear: 2021 })];
+      const result = getMostRecentCohort(projects);
+      expect(result).toBe(2021);
+    });
+  });
+});

--- a/helpers/publicGallery.ts
+++ b/helpers/publicGallery.ts
@@ -1,0 +1,68 @@
+import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
+
+export type PublicGalleryPageProps = {
+  projects: Project[];
+  currentPage: number;
+  totalPages: number;
+  total: number;
+  level: string;
+  cohortYear: number;
+  cohortYears: number[];
+};
+
+export const slugToLevel = (slug: string): LEVELS_OF_ACHIEVEMENT => {
+  const pascalCase = slug.charAt(0).toUpperCase() + slug.slice(1).toLowerCase();
+  const matchingLevel = Object.values(LEVELS_OF_ACHIEVEMENT).find(
+    (level) => level === pascalCase
+  );
+  return matchingLevel || LEVELS_OF_ACHIEVEMENT.ARTEMIS;
+};
+
+export const levelToSlug = (level: LEVELS_OF_ACHIEVEMENT): string => {
+  return level.toLowerCase();
+};
+
+/**
+ * Filters projects by achievement level and cohort year for public gallery display
+ */
+export const filterProjects = (
+  projects: Project[],
+  selectedLevel: LEVELS_OF_ACHIEVEMENT,
+  selectedCohort: number | ""
+): Project[] => {
+  return projects.filter((project) => {
+    const matchesLevel = project.achievement === selectedLevel;
+    const matchesCohort =
+      selectedCohort === "" || project.cohortYear === selectedCohort;
+    return matchesLevel && matchesCohort && !project.hasDropped;
+  });
+};
+
+/**
+ * Filters projects by achievement level only (no cohort filter)
+ */
+export const filterProjectsByLevel = (
+  projects: Project[],
+  selectedLevel: LEVELS_OF_ACHIEVEMENT
+): Project[] => {
+  return projects.filter(
+    (project) => project.achievement === selectedLevel && !project.hasDropped
+  );
+};
+
+/**
+ * Extracts unique cohort years from projects, sorted descending (newest first)
+ */
+export const extractCohortYears = (projects: Project[]): number[] => {
+  return Array.from(new Set(projects.map((p) => p.cohortYear))).sort(
+    (a, b) => b - a
+  );
+};
+
+/**
+ * Gets the most recent cohort year from a list of projects
+ */
+export const getMostRecentCohort = (projects: Project[]): number | "" => {
+  const years = extractCohortYears(projects);
+  return years.length > 0 ? years[0] : "";
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,9 @@ const customJestConfig = {
     "^@/hooks/(.*)$": "<rootDir>/hooks/$1",
     "^@/types/(.*)$": "<rootDir>/types/$1",
     "^@/helpers/(.*)$": "<rootDir>/helpers/$1",
+    "^@/styles/(.*)$": "<rootDir>/styles/$1",
+    "^@/ssg/(.*)$": "<rootDir>/ssg/$1",
+    "^@/lib/(.*)$": "<rootDir>/lib/$1",
   },
 };
 

--- a/lib/api/projectsApi.ts
+++ b/lib/api/projectsApi.ts
@@ -1,0 +1,180 @@
+/**
+ * API client for public gallery data fetching
+ * Encapsulates all API interactions related to public projects.
+ */
+
+import { Project } from "@/types/projects";
+import { getApiUrl, PAGE_SIZE } from "@/ssg/config/ssg";
+
+/**
+ * Response shape from GET /projects/public
+ */
+export interface PaginatedProjectsResponse {
+  projects: Project[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+/**
+ * Response shape from GET /projects/public/count
+ */
+export interface ProjectsCountResponse {
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * Response shape from GET /projects/public/cohorts
+ */
+export interface PublicProjectCohortsResponse {
+  cohortYears: number[];
+}
+
+/**
+ * Response shape from GET /projects/:id
+ */
+export interface ProjectResponse {
+  project: Project;
+}
+
+/**
+ * Custom error class for API errors with status code
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public endpoint: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+function buildUrl(
+  endpoint: string,
+  queryParams: Record<string, string | number | undefined> = {}
+) {
+  const baseUrl = getApiUrl().replace(/\/$/, "");
+  const url = new URL(`${baseUrl}${endpoint}`);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  return url.toString();
+}
+
+async function fetchJson<T>(
+  endpoint: string,
+  queryParams: Record<string, string | number | undefined> = {}
+): Promise<T> {
+  const url = buildUrl(endpoint, queryParams);
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new ApiError(
+      `Failed to fetch ${endpoint}: ${response.statusText}`,
+      response.status,
+      url
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch paginated public projects
+ *
+ * @param page - Page number (1-indexed)
+ * @param limit - Number of projects per page
+ * @param achievement - Optional achievement level filter (e.g., "ARTEMIS", "APOLLO")
+ * @returns Paginated projects with metadata
+ * @throws ApiError if request fails
+ */
+export async function fetchPublicProjects(
+  page = 1,
+  limit = PAGE_SIZE,
+  achievement?: string,
+  cohortYear?: number
+): Promise<PaginatedProjectsResponse> {
+  return fetchJson<PaginatedProjectsResponse>("/projects/public", {
+    page,
+    limit,
+    achievement,
+    cohortYear,
+  });
+}
+
+/**
+ * Fetch public projects count (metadata only)
+ * Used by getStaticPaths to determine number of pages without fetching all projects
+ *
+ * @param limit - Page size for totalPages calculation
+ * @param achievement - Optional achievement level filter (e.g., "artemis", "apollo")
+ * @returns Total count and total pages
+ * @throws ApiError if request fails
+ */
+export async function fetchPublicProjectsCount(
+  limit: number = PAGE_SIZE,
+  achievement?: string,
+  cohortYear?: number
+): Promise<ProjectsCountResponse> {
+  return fetchJson<ProjectsCountResponse>("/projects/public/count", {
+    limit,
+    achievement,
+    cohortYear,
+  });
+}
+
+/**
+ * Fetch cohort years that have public projects
+ */
+export async function fetchPublicProjectCohorts(): Promise<number[]> {
+  const response = await fetchJson<PublicProjectCohortsResponse>(
+    "/projects/public/cohorts"
+  );
+  return response.cohortYears;
+}
+
+/**
+ * Fetch a single project by ID
+ *
+ * @param projectId - Project ID
+ * @returns Project data
+ * @throws ApiError if request fails or project not found
+ */
+export async function fetchProjectById(
+  projectId: string | number
+): Promise<ProjectResponse> {
+  return fetchJson<ProjectResponse>(`/projects/${projectId}`);
+}
+
+/**
+ * Fetch all public project IDs for static path generation
+ * Iterates through all pages to collect complete project list
+ *
+ * @param pageSize - Page size for fetching (larger = fewer requests)
+ * @returns Array of all project IDs
+ * @throws ApiError if any request fails
+ */
+export async function fetchAllPublicProjectIds(
+  pageSize = 100
+): Promise<number[]> {
+  const firstPageData = await fetchPublicProjects(1, pageSize);
+
+  let allProjects = [...firstPageData.projects];
+  const { totalPages } = firstPageData;
+
+  // Fetch remaining pages if needed
+  for (let page = 2; page <= totalPages; page++) {
+    const pageData = await fetchPublicProjects(page, pageSize);
+    allProjects = allProjects.concat(pageData.projects);
+  }
+
+  return allProjects.map((project) => project.id);
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cypress": "^13.2.0",
     "date-fns": "^2.30.0",
     "formik": "^2.2.9",
+    "fuse.js": "^7.1.0",
     "html-react-parser": "^4.2.1",
     "jest-environment-jsdom": "^28.1.0",
     "next": "^12.1.6",

--- a/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
+++ b/pages/public-gallery/[cohortYear]/[level]/page/[page].tsx
@@ -1,0 +1,35 @@
+/* eslint-disable react/prop-types */
+import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import PublicGalleryPage from "@/components/publicGallery/PublicGalleryPage";
+import { PublicGalleryPageProps } from "@/helpers/publicGallery";
+import {
+  buildPublicGalleryPageProps,
+  getPublicGalleryStaticPaths,
+} from "@/ssg/publicGallery";
+
+const PublicGalleryCohortLevelPage: NextPage<PublicGalleryPageProps> = (
+  props
+) => {
+  return <PublicGalleryPage {...props} />;
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths = await getPublicGalleryStaticPaths();
+
+  return {
+    paths,
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<PublicGalleryPageProps> = async ({
+  params,
+}) => {
+  const level = (params?.level as string) || "artemis";
+  const page = parseInt(params?.page as string) || 1;
+  const cohortYear = Number(params?.cohortYear);
+
+  return buildPublicGalleryPageProps({ cohortYear, level, page });
+};
+
+export default PublicGalleryCohortLevelPage;

--- a/pages/public-gallery/index.tsx
+++ b/pages/public-gallery/index.tsx
@@ -8,6 +8,7 @@ import { PublicGalleryPageProps } from "@/helpers/publicGallery";
 import { fetchPublicProjectCohorts } from "@/lib/api/projectsApi";
 import { isPublicGallerySsgOffline } from "@/ssg/config/ssg";
 import { buildPublicGalleryPageProps } from "@/ssg/publicGallery";
+import { NAVBAR_HEIGHT_REM } from "@/styles/constants";
 
 type Props = {
   galleryProps: PublicGalleryPageProps | null;
@@ -25,7 +26,10 @@ const PublicGalleryIndex: NextPage<Props> = ({ galleryProps }) => {
   return (
     <>
       <CustomHead title="Public Project Gallery" />
-      <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Container
+        maxWidth="xl"
+        sx={{ pt: `calc(${NAVBAR_HEIGHT_REM} + 2rem)`, pb: 4 }}
+      >
         <Box>
           <Typography variant="h3" component="h1" gutterBottom>
             Public Project Gallery

--- a/pages/public-gallery/index.tsx
+++ b/pages/public-gallery/index.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react/prop-types */
+import { GetStaticProps } from "next";
+import type { NextPage } from "next";
+import { Box, Container, Typography } from "@mui/material";
+import CustomHead from "@/components/layout/CustomHead";
+import PublicGalleryPage from "@/components/publicGallery/PublicGalleryPage";
+import { PublicGalleryPageProps } from "@/helpers/publicGallery";
+import { fetchPublicProjectCohorts } from "@/lib/api/projectsApi";
+import { isPublicGallerySsgOffline } from "@/ssg/config/ssg";
+import { buildPublicGalleryPageProps } from "@/ssg/publicGallery";
+
+type Props = {
+  galleryProps: PublicGalleryPageProps | null;
+};
+
+/**
+ * Public gallery index page
+ * This page statically renders the newest cohort's Artemis page.
+ */
+const PublicGalleryIndex: NextPage<Props> = ({ galleryProps }) => {
+  if (galleryProps) {
+    return <PublicGalleryPage {...galleryProps} />;
+  }
+
+  return (
+    <>
+      <CustomHead title="Public Project Gallery" />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box>
+          <Typography variant="h3" component="h1" gutterBottom>
+            Public Project Gallery
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            No public projects found
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+};
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return {
+      props: {
+        galleryProps: null,
+      },
+    };
+  }
+
+  const cohortYears = await fetchPublicProjectCohorts();
+  const latestCohortYear = cohortYears[0];
+
+  if (!latestCohortYear) {
+    return {
+      props: {
+        galleryProps: null,
+      },
+    };
+  }
+
+  const result = await buildPublicGalleryPageProps({
+    cohortYear: latestCohortYear,
+    level: "artemis",
+    page: 1,
+    cohortYears,
+  });
+
+  return {
+    props: {
+      galleryProps: "props" in result ? result.props : null,
+    },
+  };
+};
+
+export default PublicGalleryIndex;

--- a/pages/public-gallery/projects/[projectId].tsx
+++ b/pages/public-gallery/projects/[projectId].tsx
@@ -1,0 +1,222 @@
+/* eslint-disable react/prop-types */
+import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import {
+  Stack,
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Container,
+} from "@mui/material";
+import CustomHead from "@/components/layout/CustomHead";
+import SpreadAttribute from "@/components/typography/SpreadAttribute";
+import GoBackButton from "@/components/buttons/GoBackButton";
+import Body from "@/components/layout/Body";
+import { Project } from "@/types/projects";
+import { noImageAvailableSrc } from "@/helpers/errors";
+import {
+  isPublicGallerySsgOffline,
+  PROJECT_PATHS_PAGE_SIZE,
+} from "@/ssg/config/ssg";
+import {
+  fetchAllPublicProjectIds,
+  fetchProjectById,
+  ApiError,
+} from "@/lib/api/projectsApi";
+
+type Props = {
+  project: Project;
+};
+
+const PublicProjectDetail: NextPage<Props> = ({ project }) => {
+  return (
+    <>
+      <CustomHead title={`${project.name} - Public Project Gallery`} />
+      <Body>
+        <GoBackButton />
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+          <Stack direction="column" alignItems="center">
+            <Box
+              component="img"
+              src={project?.posterUrl ?? noImageAvailableSrc}
+              alt={`${project?.name} Project`}
+              sx={{
+                objectFit: "cover",
+                height: "50vw",
+                maxWidth: "240px",
+                maxHeight: "240px",
+                zIndex: "1",
+              }}
+            />
+            <Card
+              sx={{
+                maxWidth: "sm",
+                width: "100%",
+                position: "relative",
+                top: "-100px",
+              }}
+              raised
+            >
+              <CardContent sx={{ marginTop: "100px" }}>
+                <Typography
+                  variant="h6"
+                  fontWeight={600}
+                  textAlign="center"
+                  mb="1.5rem"
+                >
+                  {`${project?.teamName}`}
+                </Typography>
+                {project && (
+                  <Stack spacing="0.5rem">
+                    <SpreadAttribute
+                      attribute="Project ID"
+                      value={project?.id}
+                    />
+                    <SpreadAttribute
+                      attribute="Project Name"
+                      value={project?.name}
+                    />
+                    <SpreadAttribute
+                      attribute="Level of Achievement"
+                      value={project?.achievement}
+                    />
+                    <SpreadAttribute
+                      attribute="Students"
+                      value={
+                        project?.students
+                          ? project?.students.map((student) => {
+                              return {
+                                href: `/users/${student.id}`,
+                                label: student.name,
+                              };
+                            })
+                          : []
+                      }
+                    />
+                    {project?.adviser && (
+                      <SpreadAttribute
+                        attribute="Adviser"
+                        value={{
+                          href: `/users/${project.adviser.id}`,
+                          label: project.adviser.name,
+                        }}
+                      />
+                    )}
+
+                    {project?.mentor && (
+                      <SpreadAttribute
+                        attribute="Mentor"
+                        value={{
+                          href: `/users/${project.mentor.id}`,
+                          label: project.mentor.name,
+                        }}
+                      />
+                    )}
+                    {project.proposalPdf && (
+                      <SpreadAttribute
+                        attribute="Proposal PDF"
+                        value={{
+                          href: project.proposalPdf,
+                          label: project.proposalPdf,
+                        }}
+                      />
+                    )}
+                    {project.posterUrl && (
+                      <SpreadAttribute
+                        attribute="Poster"
+                        value={{
+                          href: project.posterUrl,
+                          label: project.posterUrl,
+                        }}
+                      />
+                    )}
+                    {project.videoUrl && (
+                      <SpreadAttribute
+                        attribute="Video"
+                        value={{
+                          href: project.videoUrl,
+                          label: project.videoUrl,
+                        }}
+                      />
+                    )}
+                  </Stack>
+                )}
+              </CardContent>
+            </Card>
+          </Stack>
+        </Container>
+      </Body>
+    </>
+  );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+
+  try {
+    // Use helper function to fetch all project IDs (SRP principle)
+    const projectIds = await fetchAllPublicProjectIds(PROJECT_PATHS_PAGE_SIZE);
+
+    const paths = projectIds.map((id) => ({
+      params: { projectId: id.toString() },
+    }));
+
+    return {
+      paths,
+      fallback: false, // Show 404 for projects not in paths
+    };
+  } catch (error) {
+    // Fail Fast: Log with context
+    const errorMessage =
+      error instanceof ApiError
+        ? `API Error (${error.statusCode}): ${error.message}`
+        : `Unknown error: ${error}`;
+
+    console.error("[SSG] Failed to fetch project paths:", errorMessage);
+
+    return {
+      paths: [],
+      fallback: false,
+    };
+  }
+};
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const projectId = params?.projectId as string;
+
+  try {
+    const data = await fetchProjectById(projectId);
+    const project = data.project;
+
+    if (!project || project.hasDropped) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      props: {
+        project,
+      },
+    };
+  } catch (error) {
+    // Fail Fast: Log with context
+    const errorMessage =
+      error instanceof ApiError
+        ? `API Error (${error.statusCode}): ${error.message} at ${error.endpoint}`
+        : `Unknown error: ${error}`;
+
+    console.error(`[SSG] Failed to fetch project ${projectId}:`, errorMessage);
+
+    return {
+      notFound: true,
+    };
+  }
+};
+
+export default PublicProjectDetail;

--- a/ssg/publicGallery.ts
+++ b/ssg/publicGallery.ts
@@ -1,0 +1,112 @@
+import { GetStaticPropsResult } from "next";
+import { PublicGalleryPageProps, slugToLevel } from "@/helpers/publicGallery";
+import {
+  isPublicGallerySsgOffline,
+  PAGE_SIZE,
+  PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+} from "@/ssg/config/ssg";
+import {
+  fetchPublicProjectCohorts,
+  fetchPublicProjects,
+  fetchPublicProjectsCount,
+} from "@/lib/api/projectsApi";
+import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
+
+type BuildPublicGalleryPagePropsParams = {
+  cohortYear: number;
+  level: string;
+  page: number;
+  cohortYears?: number[];
+};
+
+export const getPublicGalleryStaticPaths = async () => {
+  if (isPublicGallerySsgOffline()) {
+    return [];
+  }
+
+  const cohortYears = await fetchPublicProjectCohorts();
+  const levels = Object.values(LEVELS_OF_ACHIEVEMENT).map((l) =>
+    l.toLowerCase()
+  );
+  const paths: {
+    params: { cohortYear: string; level: string; page: string };
+  }[] = [];
+
+  for (const cohortYear of cohortYears) {
+    for (const level of levels) {
+      const countData = await fetchPublicProjectsCount(
+        PAGE_SIZE,
+        level,
+        cohortYear
+      );
+      const totalPages = Math.max(countData.totalPages || 1, 1);
+
+      for (let p = 1; p <= totalPages; p++) {
+        paths.push({
+          params: { cohortYear: String(cohortYear), level, page: String(p) },
+        });
+      }
+    }
+  }
+
+  return paths;
+};
+
+export const buildPublicGalleryPageProps = async ({
+  cohortYear,
+  level,
+  page,
+  cohortYears,
+}: BuildPublicGalleryPagePropsParams): Promise<
+  GetStaticPropsResult<PublicGalleryPageProps>
+> => {
+  const achievementLevel = slugToLevel(level);
+
+  if (!Number.isFinite(cohortYear) || cohortYear <= 0 || page <= 0) {
+    return { notFound: true };
+  }
+
+  const [firstPageData, resolvedCohortYears] = await Promise.all([
+    fetchPublicProjects(
+      1,
+      PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+      achievementLevel,
+      cohortYear
+    ),
+    cohortYears ? Promise.resolve(cohortYears) : fetchPublicProjectCohorts(),
+  ]);
+
+  const displayTotalPages =
+    firstPageData.total > 0 ? Math.ceil(firstPageData.total / PAGE_SIZE) : 0;
+
+  if (
+    (displayTotalPages === 0 && page > 1) ||
+    (displayTotalPages > 0 && page > displayTotalPages)
+  ) {
+    return { notFound: true };
+  }
+
+  let allProjects = [...firstPageData.projects];
+
+  for (let p = 2; p <= firstPageData.totalPages; p++) {
+    const pageData = await fetchPublicProjects(
+      p,
+      PUBLIC_GALLERY_BUILD_PAGE_SIZE,
+      achievementLevel,
+      cohortYear
+    );
+    allProjects = allProjects.concat(pageData.projects);
+  }
+
+  return {
+    props: {
+      projects: allProjects,
+      currentPage: page,
+      totalPages: displayTotalPages || 1,
+      total: firstPageData.total || 0,
+      level,
+      cohortYear,
+      cohortYears: resolvedCohortYears,
+    },
+  };
+};

--- a/types/fuse-js.d.ts
+++ b/types/fuse-js.d.ts
@@ -1,0 +1,24 @@
+declare module "fuse.js" {
+  type FuseKey<T> =
+    | keyof T
+    | string
+    | { name: keyof T | string; weight?: number };
+
+  type FuseOptions<T> = {
+    keys?: FuseKey<T>[];
+    threshold?: number;
+    ignoreLocation?: boolean;
+  };
+
+  type FuseResult<T> = {
+    item: T;
+    refIndex: number;
+    score?: number;
+    matches?: unknown[];
+  };
+
+  export default class Fuse<T> {
+    constructor(list: readonly T[], options?: FuseOptions<T>);
+    search(pattern: string): FuseResult<T>[];
+  }
+}


### PR DESCRIPTION
## Summary
- adds cohort-aware static public gallery routes at /public-gallery/[cohortYear]/[level]/page/[page]
- statically renders /public-gallery/ and /public-gallery/projects/[projectId]
- adds frontend public-project API client, SSG helpers, gallery component, and SSG Jest/Cypress coverage
- enables frontend-only CI builds with PUBLIC_GALLERY_SSG_OFFLINE=true

## Verification
- npm test -- __tests__/pages/public-gallery-page.ssg.test.ts __tests__/pages/public-gallery-projectId.ssg.test.ts helpers/publicGallery.test.ts - 42 passed
- PUBLIC_GALLERY_SSG_OFFLINE=true npm run build 
- `npm run build` against local backend staging on :4000; generated cohort gallery SSG paths and 200 public project detail paths
- npx cypress run --component: local existing voting specs fail: 186 passing, 30 failing across 23 specs, all unrelated to public-gallery/SSG and mostly request-intercept waits that never fire
