### PR TITLE
feat: add routing for tab navigation

### DIFF
--- a/helpers/dashboard.test.ts
+++ b/helpers/dashboard.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable no-undef */
+import { describe, expect } from "@jest/globals";
+import { getTabFromQuery } from "./dashboard";
+
+enum TEST_TAB {
+  DEADLINES = "Upcoming Deadlines",
+  SUBMISSIONS = "Your Teams' Submissions",
+  TEAMS = "View Your Teams",
+}
+
+const TAB_QUERY_VALUES: Record<TEST_TAB, string> = {
+  [TEST_TAB.DEADLINES]: "deadlines",
+  [TEST_TAB.SUBMISSIONS]: "submissions",
+  [TEST_TAB.TEAMS]: "teams",
+};
+
+describe("#getTabFromQuery", () => {
+  it("can return the tab matching a query value", () => {
+    expect(
+      getTabFromQuery("submissions", TAB_QUERY_VALUES, TEST_TAB.DEADLINES)
+    ).toBe(TEST_TAB.SUBMISSIONS);
+  });
+
+  it("can use the first query value if the query is an array", () => {
+    expect(
+      getTabFromQuery(
+        ["teams", "submissions"],
+        TAB_QUERY_VALUES,
+        TEST_TAB.DEADLINES
+      )
+    ).toBe(TEST_TAB.TEAMS);
+  });
+
+  it("falls back when the query value is undefined", () => {
+    expect(
+      getTabFromQuery(undefined, TAB_QUERY_VALUES, TEST_TAB.DEADLINES)
+    ).toBe(TEST_TAB.DEADLINES);
+  });
+
+  it("falls back when the query value is unknown", () => {
+    expect(
+      getTabFromQuery("unknown", TAB_QUERY_VALUES, TEST_TAB.DEADLINES)
+    ).toBe(TEST_TAB.DEADLINES);
+  });
+});

--- a/helpers/dashboard.ts
+++ b/helpers/dashboard.ts
@@ -8,9 +8,9 @@ export const getTabFromQuery = <T extends string>(
   fallbackTab: T
 ) => {
   const queryValue = Array.isArray(tab) ? tab[0] : tab;
-  const matchingTab = Object.entries(tabQueryValues).find(
-    ([, tabQueryValue]) => tabQueryValue === queryValue
+  const matchingTab = (Object.keys(tabQueryValues) as T[]).find(
+    (key) => tabQueryValues[key] === queryValue
   );
 
-  return (matchingTab?.[0] as T | undefined) ?? fallbackTab;
+  return matchingTab ?? fallbackTab;
 };

--- a/helpers/dashboard.ts
+++ b/helpers/dashboard.ts
@@ -1,3 +1,16 @@
 export const transformTabNameIntoId = (label: string) => {
   return label.replace(/\s/g, "-").toLowerCase() + "-tab";
 };
+
+export const getTabFromQuery = <T extends string>(
+  tab: string | string[] | undefined,
+  tabQueryValues: Record<T, string>,
+  fallbackTab: T
+) => {
+  const queryValue = Array.isArray(tab) ? tab[0] : tab;
+  const matchingTab = Object.entries(tabQueryValues).find(
+    ([, tabQueryValue]) => tabQueryValue === queryValue
+  );
+
+  return (matchingTab?.[0] as T | undefined) ?? fallbackTab;
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ const customJestConfig = {
     "^@/hooks/(.*)$": "<rootDir>/hooks/$1",
     "^@/types/(.*)$": "<rootDir>/types/$1",
     "^@/helpers/(.*)$": "<rootDir>/helpers/$1",
+    "^@/(.*)$": "<rootDir>/$1",
   },
 };
 

--- a/pages/dashboard/administrator.tsx
+++ b/pages/dashboard/administrator.tsx
@@ -52,8 +52,9 @@ import LoadingSpinner from "@/components/emptyStates/LoadingSpinner";
 import useInfiniteFetch, {
   createBottomOfPageRef,
 } from "@/hooks/useInfiniteFetch";
-import { transformTabNameIntoId } from "@/helpers/dashboard";
+import { getTabFromQuery, transformTabNameIntoId } from "@/helpers/dashboard";
 import { Cohort } from "@/types/cohorts";
+import { useRouter } from "next/router";
 
 enum TAB {
   SUBMISSIONS = "All Teams' Milestone Submissions",
@@ -62,9 +63,17 @@ enum TAB {
   MANAGE_RELATIONSHIPS = "Manage Evaluation Relations",
 }
 
+const TAB_QUERY_VALUES: Record<TAB, string> = {
+  [TAB.SUBMISSIONS]: "submissions",
+  [TAB.EVALUATIONS]: "evaluations",
+  [TAB.COLLATED]: "collated",
+  [TAB.MANAGE_RELATIONSHIPS]: "relations",
+};
+
 const LIMIT = 50;
 
 const AdministratorDashboard: NextPage = () => {
+  const router = useRouter();
   const { cohorts, currentCohortYear } = useCohort();
   const [selectedCohortYear, setSelectedCohortYear] = useState<
     Cohort["academicYear"] | ""
@@ -348,9 +357,23 @@ const AdministratorDashboard: NextPage = () => {
   );
 
   /** Helper functions */
-  const handleTabChange = (event: React.SyntheticEvent, newValue: TAB) => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: TAB) => {
     setSelectedTab(newValue);
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, tab: TAB_QUERY_VALUES[newValue] },
+      },
+      undefined,
+      { shallow: true }
+    );
   };
+
+  useEffect(() => {
+    setSelectedTab(
+      getTabFromQuery(router.query.tab, TAB_QUERY_VALUES, TAB.SUBMISSIONS)
+    );
+  }, [router.query.tab]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSetQuerySearch = useCallback(

--- a/pages/dashboard/adviser.tsx
+++ b/pages/dashboard/adviser.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 // Components
 import Body from "@/components/layout/Body";
 import {
@@ -26,7 +26,7 @@ import useFetch, { isFetching } from "@/hooks/useFetch";
 import useAuth from "@/contexts/useAuth";
 // Helpers
 import { isFuture } from "@/helpers/dates";
-import { transformTabNameIntoId } from "@/helpers/dashboard";
+import { getTabFromQuery, transformTabNameIntoId } from "@/helpers/dashboard";
 // Type
 import type { NextPage } from "next";
 import { ROLES } from "@/types/roles";
@@ -39,6 +39,7 @@ import {
 import { VIEWER_ROLE } from "@/types/deadlines";
 import { PAGES } from "@/helpers/navigation";
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 enum TAB {
   DEADLINES = "Upcoming Deadlines",
@@ -47,7 +48,15 @@ enum TAB {
   MANAGE_RELATIONSHIPS = "Manage Evaluation Relations",
 }
 
+const TAB_QUERY_VALUES: Record<TAB, string> = {
+  [TAB.DEADLINES]: "deadlines",
+  [TAB.SUBMISSIONS]: "submissions",
+  [TAB.MANAGE_TEAMS]: "teams",
+  [TAB.MANAGE_RELATIONSHIPS]: "relations",
+};
+
 const AdviserDashboard: NextPage = () => {
+  const router = useRouter();
   const { user } = useAuth();
   const [selectedTab, setSelectedTab] = useState<TAB>(TAB.DEADLINES);
   const [isCreateAutomaticallyModalOpen, setIsCreateAutomaticallyModalOpen] =
@@ -82,9 +91,23 @@ const AdviserDashboard: NextPage = () => {
   });
 
   /** Helper functions */
-  const handleTabChange = (event: React.SyntheticEvent, newValue: TAB) => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: TAB) => {
     setSelectedTab(newValue);
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, tab: TAB_QUERY_VALUES[newValue] },
+      },
+      undefined,
+      { shallow: true }
+    );
   };
+
+  useEffect(() => {
+    setSelectedTab(
+      getTabFromQuery(router.query.tab, TAB_QUERY_VALUES, TAB.DEADLINES)
+    );
+  }, [router.query.tab]);
 
   const hasUpcomingDeadlines = deadlinesResponse?.deadlines.some(
     (deadlineDeliverable) => isFuture(deadlineDeliverable.deadline.dueBy)

--- a/pages/dashboard/mentor.tsx
+++ b/pages/dashboard/mentor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 // Components
 import Body from "@/components/layout/Body";
 import { Box, Stack, Tab, Tabs, tabsClasses, Typography } from "@mui/material";
@@ -12,7 +12,7 @@ import ProjectTable from "@/components/tables/ProjectTable";
 import useFetch, { isFetching } from "@/hooks/useFetch";
 import useAuth from "@/contexts/useAuth";
 // Helpers
-import { transformTabNameIntoId } from "@/helpers/dashboard";
+import { getTabFromQuery, transformTabNameIntoId } from "@/helpers/dashboard";
 // Type
 import type { NextPage } from "next";
 import { ROLES } from "@/types/roles";
@@ -20,13 +20,20 @@ import {
   GetMentorTeamSubmissionsResponse,
   GetProjectsResponse,
 } from "@/types/api";
+import { useRouter } from "next/router";
 
 enum TAB {
   SUBMISSIONS = "Your Teams' Submissions",
   VIEW_TEAMS = "View Your Teams",
 }
 
+const TAB_QUERY_VALUES: Record<TAB, string> = {
+  [TAB.SUBMISSIONS]: "submissions",
+  [TAB.VIEW_TEAMS]: "teams",
+};
+
 const MentorDashboard: NextPage = () => {
+  const router = useRouter();
   const { user } = useAuth();
   const [selectedTab, setSelectedTab] = useState<TAB>(TAB.SUBMISSIONS);
 
@@ -43,9 +50,23 @@ const MentorDashboard: NextPage = () => {
     });
 
   /** Helper functions */
-  const handleTabChange = (event: React.SyntheticEvent, newValue: TAB) => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: TAB) => {
     setSelectedTab(newValue);
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, tab: TAB_QUERY_VALUES[newValue] },
+      },
+      undefined,
+      { shallow: true }
+    );
   };
+
+  useEffect(() => {
+    setSelectedTab(
+      getTabFromQuery(router.query.tab, TAB_QUERY_VALUES, TAB.SUBMISSIONS)
+    );
+  }, [router.query.tab]);
 
   return (
     <Body authorizedRoles={[ROLES.MENTORS]}>

--- a/pages/dashboard/student.tsx
+++ b/pages/dashboard/student.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 // Components
 import Body from "@/components/layout/Body";
 import {
@@ -22,7 +22,7 @@ import useFetch, { isFetching } from "@/hooks/useFetch";
 import useAuth from "@/contexts/useAuth";
 // Helpers
 import { isFuture } from "@/helpers/dates";
-import { transformTabNameIntoId } from "@/helpers/dashboard";
+import { getTabFromQuery, transformTabNameIntoId } from "@/helpers/dashboard";
 // Type
 import type { NextPage } from "next";
 import { ROLES } from "@/types/roles";
@@ -32,13 +32,20 @@ import {
 } from "@/types/api";
 import { VIEWER_ROLE } from "@/types/deadlines";
 import { PAGES } from "@/helpers/navigation";
+import { useRouter } from "next/router";
 
 enum TAB {
   DEADLINES = "Upcoming Deadlines",
   EVALUATIONS = "Received Evaluations",
 }
 
+const TAB_QUERY_VALUES: Record<TAB, string> = {
+  [TAB.DEADLINES]: "deadlines",
+  [TAB.EVALUATIONS]: "evaluations",
+};
+
 const StudentDashboard: NextPage = () => {
+  const router = useRouter();
   const { user } = useAuth();
   const [selectedTab, setSelectedTab] = useState<TAB>(TAB.DEADLINES);
 
@@ -57,9 +64,23 @@ const StudentDashboard: NextPage = () => {
   });
 
   /** Helper functions */
-  const handleTabChange = (event: React.SyntheticEvent, newValue: TAB) => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: TAB) => {
     setSelectedTab(newValue);
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, tab: TAB_QUERY_VALUES[newValue] },
+      },
+      undefined,
+      { shallow: true }
+    );
   };
+
+  useEffect(() => {
+    setSelectedTab(
+      getTabFromQuery(router.query.tab, TAB_QUERY_VALUES, TAB.DEADLINES)
+    );
+  }, [router.query.tab]);
 
   const hasUpcomingDeadlines = deadlinesResponse?.deadlines.some(
     (deadlineDeliverable) => isFuture(deadlineDeliverable.deadline.dueBy)


### PR DESCRIPTION
## Context

Previously in Dashboard, when an adviser clicked into `My Team's Submissions` and I click the `Back` button, he don't go back to `My Team's Submissions` but instead to `Upcoming Deadlines`. This is quite contradictory and might cause the adviser to open up things unintentionally. 

## Changes Made

Add tab navigation for Adviser, Administrator, Mentor, Students Dashboard tab. 