### PR TITLE
fix: fix dropped team evaluation relation

### DIFF
--- a/components/relations/AdviserManageRelationsContent/AdviserManageRelationsContent.tsx
+++ b/components/relations/AdviserManageRelationsContent/AdviserManageRelationsContent.tsx
@@ -21,6 +21,7 @@ import { FC, useState } from "react";
 import SidebarActions from "./SidebarActions/SidebarActions";
 import {
   NUMBER_OF_EVALUATIONS_PER_TEAM,
+  getRelationsWithDroppedTeams,
   groupRelationsByTeam,
 } from "@/helpers/relations";
 
@@ -80,6 +81,7 @@ const AdviserManageRelationsContent: FC<Props> = ({
 
   const { teamsThatDoNotSatisfy, satisfies } =
     checkIfAllTeamsSatisfyRequirements();
+  const droppedTeamRelations = getRelationsWithDroppedTeams(relations);
 
   return (
     <>
@@ -88,6 +90,13 @@ const AdviserManageRelationsContent: FC<Props> = ({
           Summary
         </Typography>
         <Typography>{`You are currently assigned to ${projects.length} teams`}</Typography>
+        {droppedTeamRelations.length > 0 && (
+          <Typography fontWeight="bold" color="red">{`${
+            droppedTeamRelations.length
+          } evaluation relation${
+            droppedTeamRelations.length > 1 ? "s" : ""
+          } include removed teams. Delete or update the affected relations to avoid assigning evaluations to removed teams.`}</Typography>
+        )}
         {satisfies ? (
           <Typography
             fontWeight="bold"

--- a/components/tables/RelationByTeamsTable/RelationRow/RelationByTeamRow.tsx
+++ b/components/tables/RelationByTeamsTable/RelationRow/RelationByTeamRow.tsx
@@ -36,7 +36,6 @@ const RelationByTeamRow: FC<Props> = ({
   const renderProjectLink = (project: Project) => (
     <Box
       key={project.id}
-      component="span"
       sx={{ color: project.hasDropped ? "red" : "inherit" }}
     >
       <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>

--- a/components/tables/RelationByTeamsTable/RelationRow/RelationByTeamRow.tsx
+++ b/components/tables/RelationByTeamsTable/RelationRow/RelationByTeamRow.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 // Components
 import HoverLink from "@/components/typography/HoverLink";
-import { TableCell, TableRow } from "@mui/material";
+import { Box, TableCell, TableRow } from "@mui/material";
 // Helpers
 import { PAGES } from "@/helpers/navigation";
 // Types
@@ -33,6 +33,18 @@ const RelationByTeamRow: FC<Props> = ({
     return null;
   }
 
+  const renderProjectLink = (project: Project) => (
+    <Box
+      key={project.id}
+      component="span"
+      sx={{ color: project.hasDropped ? "red" : "inherit" }}
+    >
+      <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>
+        {project.teamName}
+      </HoverLink>
+    </Box>
+  );
+
   return (
     <>
       <TableRow
@@ -40,30 +52,12 @@ const RelationByTeamRow: FC<Props> = ({
           background: doesTeamFulfilRequirement ? "" : "#FFE4E4",
         }}
       >
+        <TableCell>{renderProjectLink(team)}</TableCell>
         <TableCell>
-          <HoverLink href={`${PAGES.PROJECTS}/${team.id}`}>
-            {team.teamName}
-          </HoverLink>
+          {evaluatees.map((evaluatee) => renderProjectLink(evaluatee))}
         </TableCell>
         <TableCell>
-          {evaluatees.map((evaluatee) => (
-            <HoverLink
-              key={evaluatee.id}
-              href={`${PAGES.PROJECTS}/${evaluatee.id}`}
-            >
-              {evaluatee.teamName}
-            </HoverLink>
-          ))}
-        </TableCell>
-        <TableCell>
-          {evaluators.map((evaluator) => (
-            <HoverLink
-              key={evaluator.id}
-              href={`${PAGES.PROJECTS}/${evaluator.id}`}
-            >
-              {evaluator.teamName}
-            </HoverLink>
-          ))}
+          {evaluators.map((evaluator) => renderProjectLink(evaluator))}
         </TableCell>
         {showAdviserColumn && (
           <TableCell>

--- a/components/tables/RelationCheckmarkTable/RelationCheckmarkRow/RelationCheckmarkRow.tsx
+++ b/components/tables/RelationCheckmarkTable/RelationCheckmarkRow/RelationCheckmarkRow.tsx
@@ -1,11 +1,12 @@
 import { Dispatch, FC, SetStateAction } from "react";
 // Components
 import HoverLink from "@/components/typography/HoverLink";
-import { Checkbox, TableCell, TableRow } from "@mui/material";
+import { Box, Checkbox, TableCell, TableRow } from "@mui/material";
 // Helpers
 import { PAGES } from "@/helpers/navigation";
 // Types
 import { EvaluationRelation } from "@/types/relations";
+import { Project } from "@/types/projects";
 
 type Props = {
   relation: EvaluationRelation;
@@ -34,6 +35,18 @@ const RelationCheckmarkRow: FC<Props> = ({
     });
   };
 
+  const renderProjectLink = (project: Project) => (
+    <Box
+      key={project.id}
+      component="span"
+      sx={{ color: project.hasDropped ? "red" : "inherit" }}
+    >
+      <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>
+        {project.teamName}
+      </HoverLink>
+    </Box>
+  );
+
   return (
     <>
       <TableRow>
@@ -46,14 +59,10 @@ const RelationCheckmarkRow: FC<Props> = ({
         </TableCell>
         <TableCell>{relation.id}</TableCell>
         <TableCell>
-          <HoverLink href={`${PAGES.PROJECTS}/${relation.fromProjectId}`}>
-            {relation.fromProject?.teamName}
-          </HoverLink>
+          {relation.fromProject && renderProjectLink(relation.fromProject)}
         </TableCell>
         <TableCell>
-          <HoverLink href={`${PAGES.PROJECTS}/${relation.toProjectId}`}>
-            {relation.toProject?.teamName}
-          </HoverLink>
+          {relation.toProject && renderProjectLink(relation.toProject)}
         </TableCell>
         {showAdviserColumn && (
           <TableCell>

--- a/components/tables/RelationCheckmarkTable/RelationCheckmarkRow/RelationCheckmarkRow.tsx
+++ b/components/tables/RelationCheckmarkTable/RelationCheckmarkRow/RelationCheckmarkRow.tsx
@@ -38,7 +38,6 @@ const RelationCheckmarkRow: FC<Props> = ({
   const renderProjectLink = (project: Project) => (
     <Box
       key={project.id}
-      component="span"
       sx={{ color: project.hasDropped ? "red" : "inherit" }}
     >
       <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>

--- a/components/tables/RelationTable/RelationRow/RelationRow.tsx
+++ b/components/tables/RelationTable/RelationRow/RelationRow.tsx
@@ -40,7 +40,6 @@ const RelationRow: FC<Props> = ({
   const renderProjectLink = (project: Project) => (
     <Box
       key={project.id}
-      component="span"
       sx={{ color: project.hasDropped ? "red" : "inherit" }}
     >
       <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>

--- a/components/tables/RelationTable/RelationRow/RelationRow.tsx
+++ b/components/tables/RelationTable/RelationRow/RelationRow.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from "react";
 // Components
 import HoverLink from "@/components/typography/HoverLink";
 import DeleteRelationModal from "@/components/modals/DeleteRelationModal";
-import { Button, Stack, TableCell, TableRow } from "@mui/material";
+import { Box, Button, Stack, TableCell, TableRow } from "@mui/material";
 import EditRelationModal from "@/components/modals/EditRelationModal";
 // Helpers
 import { PAGES } from "@/helpers/navigation";
@@ -37,6 +37,18 @@ const RelationRow: FC<Props> = ({
     setIsDeleteRelationOpen(true);
   };
 
+  const renderProjectLink = (project: Project) => (
+    <Box
+      key={project.id}
+      component="span"
+      sx={{ color: project.hasDropped ? "red" : "inherit" }}
+    >
+      <HoverLink href={`${PAGES.PROJECTS}/${project.id}`}>
+        {project.name}
+      </HoverLink>
+    </Box>
+  );
+
   return (
     <>
       <EditRelationModal
@@ -55,14 +67,10 @@ const RelationRow: FC<Props> = ({
       <TableRow>
         <TableCell>{relation.id}</TableCell>
         <TableCell>
-          <HoverLink href={`${PAGES.PROJECTS}/${relation.fromProjectId}`}>
-            {relation.fromProject?.name}
-          </HoverLink>
+          {relation.fromProject && renderProjectLink(relation.fromProject)}
         </TableCell>
         <TableCell>
-          <HoverLink href={`${PAGES.PROJECTS}/${relation.toProjectId}`}>
-            {relation.toProject?.name}
-          </HoverLink>
+          {relation.toProject && renderProjectLink(relation.toProject)}
         </TableCell>
         {showAdviserColumn && (
           <TableCell>

--- a/helpers/relations.test.ts
+++ b/helpers/relations.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable no-undef */
 import { describe, expect } from "@jest/globals";
-import { generateRoundRobinRelations } from "./relations";
+import {
+  generateRoundRobinRelations,
+  getRelationsWithDroppedTeams,
+} from "./relations";
 import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
+import { EvaluationRelation } from "@/types/relations";
 
 const createProject = (id: number, hasDropped = false): Project => ({
   id,
@@ -54,5 +58,41 @@ describe("#generateRoundRobinRelations", () => {
           fromProjectId === 2 || toProjectId === 2
       )
     ).toBe(false);
+  });
+});
+
+describe("#getRelationsWithDroppedTeams", () => {
+  it("can find relations that include dropped teams", () => {
+    const activeProject = createProject(1);
+    const droppedProject = createProject(2, true);
+    const otherActiveProject = createProject(3);
+
+    const relations = [
+      {
+        id: 1,
+        fromProjectId: activeProject.id,
+        toProjectId: droppedProject.id,
+        fromProject: activeProject,
+        toProject: droppedProject,
+      },
+      {
+        id: 2,
+        fromProjectId: activeProject.id,
+        toProjectId: otherActiveProject.id,
+        fromProject: activeProject,
+        toProject: otherActiveProject,
+      },
+      {
+        id: 3,
+        fromProjectId: droppedProject.id,
+        toProjectId: otherActiveProject.id,
+        fromProject: droppedProject,
+        toProject: otherActiveProject,
+      },
+    ] as EvaluationRelation[];
+
+    expect(getRelationsWithDroppedTeams(relations).map(({ id }) => id)).toEqual(
+      [1, 3]
+    );
   });
 });

--- a/helpers/relations.test.ts
+++ b/helpers/relations.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-undef */
+import { describe, expect } from "@jest/globals";
+import { generateRoundRobinRelations } from "./relations";
+import { LEVELS_OF_ACHIEVEMENT, Project } from "@/types/projects";
+
+const createProject = (id: number, hasDropped = false): Project => ({
+  id,
+  name: `Project ${id}`,
+  teamName: `Team ${id}`,
+  proposalPdf: "",
+  videoUrl: "",
+  posterUrl: "",
+  hasDropped,
+  achievement: LEVELS_OF_ACHIEVEMENT.ARTEMIS,
+  cohortYear: 2026,
+  students: [],
+});
+
+describe("#generateRoundRobinRelations", () => {
+  it("can generate round robin relations for active teams", () => {
+    const relations = generateRoundRobinRelations([
+      createProject(1),
+      createProject(2),
+      createProject(3),
+    ]);
+
+    expect(
+      relations.map(({ fromProjectId, toProjectId }) => ({
+        fromProjectId,
+        toProjectId,
+      }))
+    ).toEqual([
+      { fromProjectId: 1, toProjectId: 2 },
+      { fromProjectId: 1, toProjectId: 3 },
+      { fromProjectId: 2, toProjectId: 3 },
+      { fromProjectId: 2, toProjectId: 1 },
+      { fromProjectId: 3, toProjectId: 1 },
+      { fromProjectId: 3, toProjectId: 2 },
+    ]);
+  });
+
+  it("does not create relations for dropped teams", () => {
+    const relations = generateRoundRobinRelations([
+      createProject(1),
+      createProject(2, true),
+      createProject(3),
+      createProject(4),
+    ]);
+
+    expect(relations).toHaveLength(6);
+    expect(
+      relations.some(
+        ({ fromProjectId, toProjectId }) =>
+          fromProjectId === 2 || toProjectId === 2
+      )
+    ).toBe(false);
+  });
+});

--- a/helpers/relations.ts
+++ b/helpers/relations.ts
@@ -70,6 +70,15 @@ export const generateGroupRelations = (
   return relations;
 };
 
+export const getRelationsWithDroppedTeams = (
+  relations: EvaluationRelation[]
+) => {
+  return relations.filter(
+    (relation) =>
+      relation.fromProject?.hasDropped || relation.toProject?.hasDropped
+  );
+};
+
 export const groupRelationsByTeam = (relations: EvaluationRelation[]) => {
   const groupedRelations: Record<
     number,

--- a/helpers/relations.ts
+++ b/helpers/relations.ts
@@ -21,7 +21,8 @@ export const generateRoundRobinRelations = (
   projects: Project[]
 ): Partial<EvaluationRelation>[] => {
   const relations: Partial<EvaluationRelation>[] = [];
-  const numberOfProjects = projects.length;
+  const activeProjects = projects.filter((project) => !project.hasDropped);
+  const numberOfProjects = activeProjects.length;
 
   const numberOfEvaluations = Math.min(
     numberOfProjects - 1,
@@ -30,8 +31,8 @@ export const generateRoundRobinRelations = (
 
   for (let i = 0; i < numberOfProjects; i++) {
     for (let j = 1; j <= numberOfEvaluations; j++) {
-      const fromProject = projects[i];
-      const toProject = projects[(i + j) % numberOfProjects];
+      const fromProject = activeProjects[i];
+      const toProject = activeProjects[(i + j) % numberOfProjects];
       relations.push({
         fromProject,
         toProject,

--- a/pages/dashboard/administrator.tsx
+++ b/pages/dashboard/administrator.tsx
@@ -54,6 +54,7 @@ import useInfiniteFetch, {
 } from "@/hooks/useInfiniteFetch";
 import { getTabFromQuery, transformTabNameIntoId } from "@/helpers/dashboard";
 import { Cohort } from "@/types/cohorts";
+import { getRelationsWithDroppedTeams } from "@/helpers/relations";
 import { useRouter } from "next/router";
 
 enum TAB {
@@ -338,6 +339,9 @@ const AdministratorDashboard: NextPage = () => {
     endpoint: `/relations`,
     requiresAuthorization: true,
   });
+  const droppedTeamRelations = getRelationsWithDroppedTeams(
+    relationsResponse?.relations ?? []
+  );
 
   /** To fetch more projects when the bottom of the page is reached */
   const observer = useRef<IntersectionObserver | null>(null);
@@ -796,12 +800,21 @@ const AdministratorDashboard: NextPage = () => {
                 }
               >
                 {relationsResponse && relationsResponse.relations && (
-                  <RelationTable
-                    relations={relationsResponse.relations}
-                    mutate={mutateRelations}
-                    projects={projectsResponse?.projects ?? []}
-                    showAdviserColumn
-                  />
+                  <Stack gap="1rem">
+                    {droppedTeamRelations.length > 0 && (
+                      <Typography fontWeight="bold" color="red">{`${
+                        droppedTeamRelations.length
+                      } evaluation relation${
+                        droppedTeamRelations.length > 1 ? "s" : ""
+                      } include removed teams. Delete or update the affected relations to avoid assigning evaluations to removed teams.`}</Typography>
+                    )}
+                    <RelationTable
+                      relations={relationsResponse.relations}
+                      mutate={mutateRelations}
+                      projects={projectsResponse?.projects ?? []}
+                      showAdviserColumn
+                    />
+                  </Stack>
                 )}
               </NoDataWrapper>
             </Stack>


### PR DESCRIPTION
# Context

Previously, the auto-assignment for evaluation relations doesn't take into account removed teams, forcing manual evaluation as long as one team is removed.

# Changes Made

1. Fix auto-assignment for evaluation relations to only consider non-dropped teams
2. Give warning when the evaluation relations include dropped teams
3. Add red highlight for dropped teams in evaluation relations

