### PR TITLE
fix: add missing project reference

### DIFF
--- a/components/cards/ImageCard/ImageCard.cy.tsx
+++ b/components/cards/ImageCard/ImageCard.cy.tsx
@@ -51,6 +51,16 @@ describe("<ImageCard />", () => {
     cy.contains("Action").should("be.visible");
   });
 
+  it("should render title as a link without triggering card click", () => {
+    mount(<ImageCard {...cardProps} />);
+
+    cy.contains("a", cardProps.title)
+      .should("be.visible")
+      .and("have.attr", "href", cardProps.titleHref)
+      .click({ ctrlKey: true });
+    cy.get("@cardClick").should("not.have.been.called");
+  });
+
   it("should call onCardClick when card is clicked", () => {
     mount(<ImageCard {...cardProps} />);
 

--- a/components/cards/ImageCard/ImageCard.cy.tsx
+++ b/components/cards/ImageCard/ImageCard.cy.tsx
@@ -9,6 +9,7 @@ describe("<ImageCard />", () => {
     id: string;
     idDisplay: string;
     title: string;
+    titleHref: string;
     imageSrc: string;
     actionButton?: React.ReactNode;
     extraContent?: React.ReactNode;
@@ -22,6 +23,7 @@ describe("<ImageCard />", () => {
       id: "test-card-id",
       idDisplay: "1",
       title: "Test Card Title",
+      titleHref: "/projects/1",
       imageSrc: "/images/no-image-available.png",
       actionButton: <button>Action</button>,
       extraContent: <div>Extra Content</div>,

--- a/components/cards/ImageCard/ImageCard.tsx
+++ b/components/cards/ImageCard/ImageCard.tsx
@@ -74,8 +74,10 @@ const ImageCard: FC<Props> = ({
         <Stack sx={{ height: "100%", gap: "0.5rem" }}>
           <Link href={titleHref} passHref>
             <Typography
+              component="a"
               align="center"
               fontWeight={600}
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
               sx={{
                 paddingX: "1.5rem",
                 whiteSpace: "normal", // Allow text to wrap
@@ -83,6 +85,8 @@ const ImageCard: FC<Props> = ({
                 textOverflow: "ellipsis",
                 cursor: "pointer",
                 transition: BASE_TRANSITION,
+                color: "inherit",
+                textDecoration: "none",
                 "&:hover": {
                   textDecoration: "underline",
                   color: "secondary.main",

--- a/components/cards/ImageCard/ImageCard.tsx
+++ b/components/cards/ImageCard/ImageCard.tsx
@@ -2,12 +2,14 @@ import { noImageAvailableSrc } from "@/helpers/errors";
 import { getThumbnailUrl } from "@/helpers/images";
 import { A4_ASPECT_RATIO, BASE_TRANSITION } from "@/styles/constants";
 import { Card, CardContent, Stack, Typography } from "@mui/material";
+import Link from "next/link";
 import React, { FC } from "react";
 
 type Props = {
   id: string;
   idDisplay: string;
   title: string;
+  titleHref: string;
   imageSrc?: string;
   actionButton?: React.ReactNode;
   extraContent?: React.ReactNode;
@@ -22,6 +24,7 @@ const ImageCard: FC<Props> = ({
   id,
   idDisplay,
   title,
+  titleHref,
   imageSrc,
   actionButton,
   extraContent,
@@ -69,26 +72,28 @@ const ImageCard: FC<Props> = ({
         }}
       >
         <Stack sx={{ height: "100%", gap: "0.5rem" }}>
-          <Typography
-            align="center"
-            fontWeight={600}
-            sx={{
-              paddingX: "1.5rem",
-              whiteSpace: "normal", // Allow text to wrap
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              cursor: "pointer",
-              transition: BASE_TRANSITION,
-              "&:hover": {
-                textDecoration: "underline",
-                color: "secondary.main",
-              },
-              // Responsive font size
-              fontSize: { xs: "1rem", sm: "1.2rem", md: "1.4rem" },
-            }}
-          >
-            {title}
-          </Typography>
+          <Link href={titleHref} passHref>
+            <Typography
+              align="center"
+              fontWeight={600}
+              sx={{
+                paddingX: "1.5rem",
+                whiteSpace: "normal", // Allow text to wrap
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                cursor: "pointer",
+                transition: BASE_TRANSITION,
+                "&:hover": {
+                  textDecoration: "underline",
+                  color: "secondary.main",
+                },
+                // Responsive font size
+                fontSize: { xs: "1rem", sm: "1.2rem", md: "1.4rem" },
+              }}
+            >
+              {title}
+            </Typography>
+          </Link>
           <div
             title="Click to view full image in new tab"
             style={{

--- a/components/cards/ProjectCard/ProjectCard.tsx
+++ b/components/cards/ProjectCard/ProjectCard.tsx
@@ -21,6 +21,7 @@ const ProjectCard: FC<Props> = ({ project, priority = false }) => {
       id={project.id.toString()}
       idDisplay={project.id.toString()}
       title={project.teamName}
+      titleHref={`${PAGES.PROJECTS}/${project.id}`}
       imageSrc={project.posterUrl}
       imgAlt={`${project.name} Poster`}
       priority={priority}

--- a/components/cards/VotingCard/VotingCard.tsx
+++ b/components/cards/VotingCard/VotingCard.tsx
@@ -1,4 +1,5 @@
 import ImageCard from "@/components/cards/ImageCard/ImageCard";
+import { PAGES } from "@/helpers/navigation";
 import { Project } from "@/types/projects";
 import { Button } from "@mui/material";
 import { Dispatch, FC, SetStateAction } from "react";
@@ -28,6 +29,7 @@ const VotingCard: FC<Props> = ({
       id={`${candidate.id}-candidate-card`}
       idDisplay={candidate.id.toString()}
       title={candidate.name}
+      titleHref={`${PAGES.PROJECTS}/${candidate.id}`}
       imageSrc={candidate.posterUrl}
       imgAlt={`${candidate.name} Poster`}
       hoverEffect={false}


### PR DESCRIPTION
# Context

In the "Projects" Tab, each title is hoverable and shows up blue and underlined, but cannot be clicked.

# Changes Made

Link the title to the project details page. 