### PR TITLE
test: add e2e coverage for peer-review dashboard authorization

### DIFF
--- a/cypress/e2e/dashboard/student-dashboard-authorization.cy.js
+++ b/cypress/e2e/dashboard/student-dashboard-authorization.cy.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-undef */
+
+describe("Testing student dashboard object-level authorization", () => {
+  beforeEach(() => {
+    cy.login("student1@skylab.com", "Password123");
+  });
+
+  afterEach(() => {
+    cy.get("#nav-sign-out").click();
+  });
+
+  it("Denies a student reading another student's evaluations-feedbacks", () => {
+    cy.request({
+      url: "/dashboard/student/1/evaluations-feedbacks",
+      failOnStatusCode: false,
+    }).then(({ status }) => {
+      expect(status).to.eq(401);
+    });
+  });
+
+  it("Denies a student reading another student's deadlines", () => {
+    cy.request({
+      url: "/dashboard/student/1/deadlines",
+      failOnStatusCode: false,
+    }).then(({ status }) => {
+      expect(status).to.eq(401);
+    });
+  });
+
+  it("Allows a student reading their own evaluations-feedbacks", () => {
+    cy.request({
+      url: "/dashboard/student/2/evaluations-feedbacks",
+      failOnStatusCode: false,
+    }).then(({ status }) => {
+      expect(status).to.eq(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Cypress spec covering the peer-review dashboard IDOR fixed in
  orbital-skylab/skylab-backend#181. No production code changes.

## Depends on
- orbital-skylab/skylab-backend#181 — please merge that first. This
  spec asserts 401 on cross-student access and will fail against an
  unpatched backend.

## Related
- Relates to orbital-skylab/skylab-frontend#102