### PR TITLE
feat: add administrator Feedback dashboard

### DIFF
--- a/components/modals/AddDeadlineModal/AddDeadlineModal.tsx
+++ b/components/modals/AddDeadlineModal/AddDeadlineModal.tsx
@@ -157,20 +157,23 @@ const AddDeadlineModal: FC<Props> = ({
                           : []
                       }
                     />
-
-                    <Dropdown
-                      label="Evaluator Type"
-                      name="evaluatorType"
-                      formik={formik}
-                      options={
-                        [
-                          { label: "Adviser", value: EVALUATOR_TYPE.ADVISER },
-                          { label: "Team", value: EVALUATOR_TYPE.TEAM },
-                          { label: "Both", value: EVALUATOR_TYPE.BOTH },
-                        ] as { label: string; value: EVALUATOR_TYPE }[]
-                      }
-                    />
                   </>
+                )}
+                {[DEADLINE_TYPE.EVALUATION, DEADLINE_TYPE.FEEDBACK].includes(
+                  formik.values.type
+                ) && (
+                  <Dropdown
+                    label="Evaluator Type"
+                    name="evaluatorType"
+                    formik={formik}
+                    options={
+                      [
+                        { label: "Adviser", value: EVALUATOR_TYPE.ADVISER },
+                        { label: "Team", value: EVALUATOR_TYPE.TEAM },
+                        { label: "Both", value: EVALUATOR_TYPE.BOTH },
+                      ] as { label: string; value: EVALUATOR_TYPE }[]
+                    }
+                  />
                 )}
               </Stack>
               <Stack
@@ -209,7 +212,8 @@ const addDeadlineValidationSchema = Yup.object().shape({
     then: Yup.string().required(ERRORS.REQUIRED),
   }),
   evaluatorType: Yup.string().when("type", {
-    is: DEADLINE_TYPE.EVALUATION,
+    is: (type: DEADLINE_TYPE) =>
+      [DEADLINE_TYPE.EVALUATION, DEADLINE_TYPE.FEEDBACK].includes(type),
     then: Yup.string().required(ERRORS.REQUIRED),
   }),
 });

--- a/components/modals/EditDeadlineModal/EditDeadlineModal.tsx
+++ b/components/modals/EditDeadlineModal/EditDeadlineModal.tsx
@@ -85,7 +85,9 @@ const EditDeadlineModal: FC<Props> = ({
           ? Number(values.evaluatingMilestoneId)
           : undefined,
       evaluatorType:
-        values.type === DEADLINE_TYPE.EVALUATION && values.evaluatorType !== ""
+        [DEADLINE_TYPE.EVALUATION, DEADLINE_TYPE.FEEDBACK].includes(
+          values.type
+        ) && values.evaluatorType !== ""
           ? values.evaluatorType
           : undefined,
     };
@@ -166,18 +168,21 @@ const EditDeadlineModal: FC<Props> = ({
                           : []
                       }
                     />
-
-                    <Dropdown
-                      label="Evaluator Type"
-                      name="evaluatorType"
-                      formik={formik}
-                      options={[
-                        { label: "Adviser", value: EVALUATOR_TYPE.ADVISER },
-                        { label: "Team", value: EVALUATOR_TYPE.TEAM },
-                        { label: "Both", value: EVALUATOR_TYPE.BOTH },
-                      ]}
-                    />
                   </>
+                )}
+                {[DEADLINE_TYPE.EVALUATION, DEADLINE_TYPE.FEEDBACK].includes(
+                  formik.values.type
+                ) && (
+                  <Dropdown
+                    label="Evaluator Type"
+                    name="evaluatorType"
+                    formik={formik}
+                    options={[
+                      { label: "Adviser", value: EVALUATOR_TYPE.ADVISER },
+                      { label: "Team", value: EVALUATOR_TYPE.TEAM },
+                      { label: "Both", value: EVALUATOR_TYPE.BOTH },
+                    ]}
+                  />
                 )}
               </Stack>
               <Stack
@@ -217,7 +222,8 @@ const editDeadlineValidationSchema = Yup.object().shape({
     then: Yup.string().required(ERRORS.REQUIRED),
   }),
   evaluatorType: Yup.string().when("type", {
-    is: DEADLINE_TYPE.EVALUATION,
+    is: (type: DEADLINE_TYPE) =>
+      [DEADLINE_TYPE.EVALUATION, DEADLINE_TYPE.FEEDBACK].includes(type),
     then: Yup.string().required(ERRORS.REQUIRED),
   }),
 });

--- a/components/modals/SendEvaluationReminderModal/SendEvaluationReminderModal.tsx
+++ b/components/modals/SendEvaluationReminderModal/SendEvaluationReminderModal.tsx
@@ -35,7 +35,7 @@ import {
   GetAdministratorAllTeamMilestoneSubmissionsResponse,
   HTTP_METHOD,
 } from "@/types/api";
-import { Deadline } from "@/types/deadlines";
+import { DEADLINE_TYPE, Deadline } from "@/types/deadlines";
 import { Cohort } from "@/types/cohorts";
 import { ApiServiceBuilder } from "@/helpers/api";
 
@@ -93,6 +93,13 @@ const SendEvaluationReminderModal: FC<Props> = ({
   const [selectedEvaluationDeadline, setSelectedEvaluationDeadline] = useState<
     Deadline | undefined
   >(evaluationDeadlines[0]);
+  const isFeedback =
+    (selectedEvaluationDeadline?.type ?? evaluationDeadlines[0]?.type) ===
+    DEADLINE_TYPE.FEEDBACK;
+  const deadlineLabel = isFeedback ? "Feedback" : "Evaluation";
+  const submissionsEndpoint = isFeedback
+    ? "/dashboard/administrator/feedback"
+    : "/dashboard/administrator/evaluations";
   const [sending, setSending] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState("");
@@ -301,7 +308,7 @@ const SendEvaluationReminderModal: FC<Props> = ({
 
   const { data: allTeamsEvaluations } =
     useFetch<GetAdministratorAllTeamMilestoneSubmissionsResponse>({
-      endpoint: `/dashboard/administrator/evaluations`,
+      endpoint: submissionsEndpoint,
       queryParams: memoQueryParams,
       requiresAuthorization: true,
     });
@@ -315,12 +322,12 @@ const SendEvaluationReminderModal: FC<Props> = ({
   return (
     <>
       <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-        <DialogTitle>Send Evaluation Reminders</DialogTitle>
+        <DialogTitle>{`Send ${deadlineLabel} Reminders`}</DialogTitle>
         <DialogContent>
           <DialogContentText sx={{ mb: 2 }}>
             {emailComposeStage
               ? "Review and edit the email before sending"
-              : "Select evaluators (Advisers or Teams) who have incomplete evaluations to send them a reminder."}
+              : `Select evaluators (Advisers or Teams) who have incomplete ${deadlineLabel.toLowerCase()} submissions to send them a reminder.`}
           </DialogContentText>
 
           {emailComposeStage ? (
@@ -358,6 +365,7 @@ const SendEvaluationReminderModal: FC<Props> = ({
                   selectedEvaluators={selectedEvaluators}
                   onSelectEvaluator={handleSelectEvaluator}
                   onSelectAll={handleSelectAll}
+                  deadlineLabel={deadlineLabel}
                 />
               </TabPanel>
             </>
@@ -433,6 +441,7 @@ interface RemindersListProps {
   selectedEvaluators: string[];
   onSelectEvaluator: (id: string) => void;
   onSelectAll: () => void;
+  deadlineLabel: string;
 }
 
 function RemindersList({
@@ -440,6 +449,7 @@ function RemindersList({
   selectedEvaluators,
   onSelectEvaluator,
   onSelectAll,
+  deadlineLabel,
 }: RemindersListProps) {
   const allSelected =
     evaluators.length > 0 && selectedEvaluators.length === evaluators.length;
@@ -458,7 +468,7 @@ function RemindersList({
       >
         <CheckCircleIcon color="success" sx={{ fontSize: 48, mb: 1 }} />
         <Typography variant="h6" gutterBottom>
-          All evaluations have been submitted!
+          {`All ${deadlineLabel.toLowerCase()} submissions have been submitted!`}
         </Typography>
         <Typography variant="body2" color="text.secondary">
           There are no evaluators that need reminders for this deadline.
@@ -572,7 +582,9 @@ function RemindersList({
                       component="span"
                       sx={{ color: "error.main", fontWeight: 500, mt: 0.5 }}
                     >
-                      Missing {evaluator.missingCount} evaluation(s)
+                      {`Missing ${
+                        evaluator.missingCount
+                      } ${deadlineLabel.toLowerCase()} submission(s)`}
                     </Typography>
                   </Box>
                 }

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
@@ -179,6 +179,28 @@ describe("mapEvaluationData", () => {
     });
   });
 
+  it("matches the selected evaluation by deadline id when submissions contain multiple deadlines", () => {
+    const [result] = mapEvaluationData(
+      [
+        {
+          ...adviserEvaluation,
+          submission: [
+            teamEvaluation.submission[0],
+            adviserEvaluation.submission[0],
+          ],
+        },
+      ],
+      [adviserEvaluationDeadline],
+      true
+    );
+
+    expect(result).toMatchObject({
+      "Adviser Feedback Review Submission Updated At":
+        "2026-03-08T10:00:00.000Z",
+      "Adviser Feedback Review Status": "SUBMITTED_LATE",
+    });
+  });
+
   it("adds submitted answers as question columns", () => {
     const [result] = mapEvaluationData(
       [

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable no-undef */
 import { describe, expect, it } from "@jest/globals";
 
-import { DEADLINE_TYPE, EVALUATOR_TYPE } from "@/types/deadlines";
+import {
+  DEADLINE_TYPE,
+  EVALUATOR_TYPE,
+  QUESTION_TYPE,
+} from "@/types/deadlines";
 import { LEVELS_OF_ACHIEVEMENT } from "@/types/projects";
 import { mapEvaluationData } from "./EvaluationsActionRow.helpers";
 
@@ -175,6 +179,70 @@ describe("mapEvaluationData", () => {
     });
   });
 
+  it("adds submitted answers as question columns", () => {
+    const [result] = mapEvaluationData(
+      [
+        {
+          ...teamEvaluation,
+          submission: {
+            ...teamEvaluation.submission[0],
+            answers: [
+              {
+                questionId: 91,
+                answer: "Clear and actionable",
+                question: {
+                  id: 91,
+                  sectionId: 9,
+                  questionNumber: 2,
+                  question: "What was useful?",
+                  type: QUESTION_TYPE.PARAGRAPH,
+                },
+              },
+            ],
+          },
+        },
+      ],
+      [teamEvaluationDeadline],
+      true
+    );
+
+    expect(result).toMatchObject({
+      "Peer Critique Round 1 - Q2: What was useful?": "Clear and actionable",
+    });
+  });
+
+  it("keeps answer columns when the first exported row is unsubmitted", () => {
+    const submittedEvaluation = {
+      ...teamEvaluation,
+      submission: {
+        ...teamEvaluation.submission[0],
+        answers: [
+          {
+            questionId: 91,
+            answer: "Useful examples",
+            question: {
+              id: 91,
+              sectionId: 9,
+              questionNumber: 2,
+              question: "What was useful?",
+              type: QUESTION_TYPE.PARAGRAPH,
+            },
+          },
+        ],
+      },
+    };
+    const [unsubmittedResult] = mapEvaluationData(
+      [{ ...teamEvaluation, submission: undefined }, submittedEvaluation],
+      [teamEvaluationDeadline],
+      true
+    );
+
+    expect(unsubmittedResult).toHaveProperty(
+      "Peer Critique Round 1 - Q2: What was useful?",
+      ""
+    );
+  });
+
   it("creates dynamic status columns across multiple evaluation deadlines", () => {
     const [teamResult, adviserResult] = mapEvaluationData(
       [teamEvaluation, adviserEvaluation],
@@ -187,12 +255,12 @@ describe("mapEvaluationData", () => {
       "Evaluator Student 1": "Chloe",
       "Evaluator Email 1": "chloe@example.com",
       "Peer Critique Round 1 Status": "SUBMITTED",
-      "Adviser Feedback Review Status": "NOT_SUBMITTED",
+      "Adviser Feedback Review Status": "N/A",
     });
 
     expect(adviserResult).toMatchObject({
       "Evaluator Type": "Adviser",
-      "Peer Critique Round 1 Status": "NOT_SUBMITTED",
+      "Peer Critique Round 1 Status": "N/A",
       "Adviser Feedback Review Status": "SUBMITTED_LATE",
     });
   });

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
@@ -1,6 +1,6 @@
 import { generateSubmissionStatus } from "@/helpers/submissions";
 import { Deadline } from "@/types/deadlines";
-import { PossibleSubmission, STATUS } from "@/types/submissions";
+import { PossibleSubmission, STATUS, Submission } from "@/types/submissions";
 
 const getStatusText = (status: STATUS): string => {
   switch (status) {
@@ -13,15 +13,82 @@ const getStatusText = (status: STATUS): string => {
   }
 };
 
+const getAnswerColumn = (
+  deadline: Deadline,
+  answer: Submission["answers"][number]
+) =>
+  `${deadline.name} - Q${
+    answer.question?.questionNumber ?? answer.questionId
+  }: ${answer.question?.question ?? `Question ${answer.questionId}`}`;
+
+const getSubmissionForDeadline = (
+  evaluation: PossibleSubmission,
+  deadlineId: number
+) => {
+  const submission = evaluation.submission;
+  if (Array.isArray(submission)) {
+    return submission.find((item) => item.deadlineId === deadlineId);
+  }
+  return submission?.deadlineId === deadlineId ? submission : undefined;
+};
+
+const isDeadlineApplicable = (
+  deadline: Deadline,
+  evaluation: PossibleSubmission
+) =>
+  !deadline.evaluatorType ||
+  deadline.evaluatorType === "Both" ||
+  (deadline.evaluatorType === "Team" && !!evaluation.fromProject) ||
+  (deadline.evaluatorType === "Adviser" && !!evaluation.fromUser);
+
+const getAnswerColumnsByDeadline = (
+  evaluations: PossibleSubmission[],
+  deadlines: Deadline[]
+) =>
+  new Map(
+    deadlines.map((deadline) => [
+      deadline.id,
+      Array.from(
+        new Set(
+          evaluations.flatMap((evaluation) =>
+            (
+              getSubmissionForDeadline(evaluation, deadline.id)?.answers ?? []
+            ).map((answer) => getAnswerColumn(deadline, answer))
+          )
+        )
+      ),
+    ])
+  );
+
+const mapAnswerColumns = (
+  submission: Submission | undefined,
+  deadline: Deadline,
+  columns: string[]
+) => ({
+  ...Object.fromEntries(columns.map((column) => [column, ""])),
+  ...Object.fromEntries(
+    (submission?.answers ?? []).map((answer) => [
+      getAnswerColumn(deadline, answer),
+      answer.answer ?? "",
+    ])
+  ),
+});
+
 export const mapEvaluationData = (
   evaluations: PossibleSubmission[],
   csvEvaluations: Deadline[],
   isSelectedEvaluationExport = false
 ) => {
+  const answerColumnsByDeadline = getAnswerColumnsByDeadline(
+    evaluations,
+    csvEvaluations
+  );
+
   return evaluations.map((res) => {
     const evaluatorProject = res.fromProject;
     const evaluatorUser = res.fromUser;
     const evaluateeProject = res.toProject;
+    const evaluateeUser = res.toUser;
 
     const evaluatorStudents = evaluatorProject?.students ?? [];
     const evaluateeStudents = evaluateeProject?.students ?? [];
@@ -52,6 +119,12 @@ export const mapEvaluationData = (
       "Evaluator Email 2": evaluatorEmail2,
 
       // Evaluatee Info
+      "Evaluatee Type": evaluateeProject ? "Team" : "Adviser",
+      Evaluatee:
+        evaluateeProject?.teamName ??
+        evaluateeProject?.name ??
+        evaluateeUser?.name ??
+        "N/A",
       "Evaluatee Team": evaluateeProject?.teamName ?? "N/A",
       "Evaluatee Student 1": evaluateeStudents[0]?.name ?? "",
       "Evaluatee Student 2": evaluateeStudents[1]?.name ?? "",
@@ -75,9 +148,26 @@ export const mapEvaluationData = (
           sub?.updatedAt ?? "",
         [`${selectedEvaluationDeadline.name} Status`]:
           getStatusText(submissionStatus),
+        ...mapAnswerColumns(
+          sub,
+          selectedEvaluationDeadline,
+          answerColumnsByDeadline.get(selectedEvaluationDeadline.id) ?? []
+        ),
       };
     } else {
       const evaluationStatuses = csvEvaluations.map((evaluation) => {
+        if (!isDeadlineApplicable(evaluation, res)) {
+          return {
+            [`${evaluation.name} Submission Updated At`]: "",
+            [`${evaluation.name} Status`]: "N/A",
+            ...mapAnswerColumns(
+              undefined,
+              evaluation,
+              answerColumnsByDeadline.get(evaluation.id) ?? []
+            ),
+          };
+        }
+
         const submissionsArray = Array.isArray(res.submission)
           ? res.submission
           : res.submission
@@ -104,6 +194,11 @@ export const mapEvaluationData = (
         return {
           [`${evaluation.name} Submission Updated At`]: sub.updatedAt ?? "",
           [`${evaluation.name} Status`]: getStatusText(submissionStatus),
+          ...mapAnswerColumns(
+            sub,
+            evaluation,
+            answerColumnsByDeadline.get(evaluation.id) ?? []
+          ),
         };
       });
 

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
@@ -132,9 +132,10 @@ export const mapEvaluationData = (
 
     if (isSelectedEvaluationExport) {
       const selectedEvaluationDeadline = csvEvaluations[0];
-      const sub = Array.isArray(res.submission)
-        ? res.submission[0]
-        : res.submission;
+      const sub = getSubmissionForDeadline(
+        res,
+        selectedEvaluationDeadline.id
+      );
       const submissionStatus = generateSubmissionStatus({
         submissionId: sub?.id,
         isDraft: false,
@@ -168,15 +169,7 @@ export const mapEvaluationData = (
           };
         }
 
-        const submissionsArray = Array.isArray(res.submission)
-          ? res.submission
-          : res.submission
-          ? [res.submission]
-          : [];
-
-        const sub = submissionsArray.find(
-          (sub) => sub.deadlineId === evaluation.id
-        );
+        const sub = getSubmissionForDeadline(res, evaluation.id);
 
         if (!sub) {
           return {

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.helpers.ts
@@ -132,10 +132,7 @@ export const mapEvaluationData = (
 
     if (isSelectedEvaluationExport) {
       const selectedEvaluationDeadline = csvEvaluations[0];
-      const sub = getSubmissionForDeadline(
-        res,
-        selectedEvaluationDeadline.id
-      );
+      const sub = getSubmissionForDeadline(res, selectedEvaluationDeadline.id);
       const submissionStatus = generateSubmissionStatus({
         submissionId: sub?.id,
         isDraft: false,

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
@@ -209,6 +209,7 @@ describe("EvaluationsActionRow", () => {
           deadlineId: evaluationOne.id,
           dropped: true,
           evaluatorTypeFilter: "Team",
+          includeAnswers: true,
           submissionStatus: SUBMISSION_STATUS.SUBMITTED,
         },
         requiresAuthorization: true,

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.test.tsx
@@ -96,6 +96,13 @@ const evaluationTwo = {
   evaluatorType: EVALUATOR_TYPE.ADVISER,
 };
 
+const feedbackDeadline = {
+  ...evaluationOne,
+  id: 23,
+  name: "Team Feedback",
+  type: DEADLINE_TYPE.FEEDBACK,
+};
+
 const defaultProps = {
   selectedEvaluationsDeadline: null,
   handleSelectedEvaluationsDeadlineChange: jest.fn(),
@@ -149,6 +156,17 @@ describe("EvaluationsActionRow", () => {
     expect(
       screen.getByTestId("send-evaluation-reminder-modal").textContent
     ).toBe("Adviser-2024");
+  });
+
+  it("supports feedback-specific deadline labels", () => {
+    render(
+      <EvaluationsActionRow
+        {...defaultProps}
+        evaluationsDeadlines={[feedbackDeadline]}
+      />
+    );
+
+    expect(screen.getByLabelText("Feedback").textContent).toBe("All Feedback");
   });
 
   it("exports CSV with the selected filters and renders the mapped download payload", async () => {

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
@@ -99,6 +99,7 @@ const EvaluationsActionRow: FC<Props> = ({
           deadlineId: selectedEvaluationsDeadline?.id,
           dropped: viewHasDropped,
           evaluatorTypeFilter: selectedEvaluatorType,
+          includeAnswers: true,
           ...(selectedSubmissionStatus === SUBMISSION_STATUS.ALL
             ? {}
             : { submissionStatus: selectedSubmissionStatus }),

--- a/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsActionRow/EvaluationsActionRow.tsx
@@ -26,7 +26,7 @@ import {
   GetAdministratorAllTeamMilestoneSubmissionsResponse,
   HTTP_METHOD,
 } from "@/types/api";
-import { Deadline } from "@/types/deadlines";
+import { DEADLINE_TYPE, Deadline } from "@/types/deadlines";
 import { SUBMISSION_STATUS } from "@/types/submissions";
 import { Cohort } from "@/types/cohorts";
 
@@ -70,6 +70,17 @@ const EvaluationsActionRow: FC<Props> = ({
   const [isExporting, setIsExporting] = useState(false);
   const [csvData, setCsvData] = useState<Record<string, string | number>[]>([]);
   const [open, setOpen] = useState(false);
+  const deadlineType =
+    selectedEvaluationsDeadline?.type ?? evaluationsDeadlines[0]?.type;
+  const isFeedback = deadlineType === DEADLINE_TYPE.FEEDBACK;
+  const deadlineLabel = isFeedback ? "Feedback" : "Evaluation";
+  const allDeadlinesLabel = isFeedback ? "All Feedback" : "All Evaluations";
+  const submissionsEndpoint = isFeedback
+    ? "/dashboard/administrator/feedback"
+    : "/dashboard/administrator/evaluations";
+  const csvErrorMessage = isFeedback
+    ? "No feedback submission data found"
+    : "No team evaluation submission data found";
 
   const exportCsv = async () => {
     setIsExporting(true);
@@ -82,7 +93,7 @@ const EvaluationsActionRow: FC<Props> = ({
 
       const fetchAllTeamsEvaluations = new ApiServiceBuilder({
         method: HTTP_METHOD.GET,
-        endpoint: `/dashboard/administrator/evaluations`,
+        endpoint: submissionsEndpoint,
         queryParams: {
           cohortYear: cohortYearForExport,
           deadlineId: selectedEvaluationsDeadline?.id,
@@ -99,7 +110,7 @@ const EvaluationsActionRow: FC<Props> = ({
         await res.json();
 
       if (!data || !data.submissions) {
-        throw new Error("No team evaluation submission data found");
+        throw new Error(csvErrorMessage);
       }
       const csvEvaluations = selectedEvaluationsDeadline
         ? [selectedEvaluationsDeadline]
@@ -120,7 +131,7 @@ const EvaluationsActionRow: FC<Props> = ({
     <Stack gap="0.5rem">
       <Stack direction="row" gap="0.5rem" alignItems="center">
         <TextField
-          label="Evaluation"
+          label={deadlineLabel}
           value={
             selectedEvaluationsDeadline
               ? JSON.stringify(selectedEvaluationsDeadline)
@@ -130,7 +141,7 @@ const EvaluationsActionRow: FC<Props> = ({
           select
           size="small"
         >
-          <MenuItem value={"0"}>All Evaluations</MenuItem>
+          <MenuItem value={"0"}>{allDeadlinesLabel}</MenuItem>
           {evaluationsDeadlines &&
             evaluationsDeadlines.map((deadline) => (
               <MenuItem key={deadline.id} value={JSON.stringify(deadline)}>

--- a/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsRow/EvaluationsRow.tsx
@@ -118,9 +118,15 @@ const EvaluationsRow: FC<Props> = ({ data, evaluationDeadlines, deadline }) => {
 
       {/* Evaluatee Name Column */}
       <TableCell>
-        <HoverLink href={`${PAGES.PROJECTS}/${data.toProject?.id}`}>
-          {data.toProject?.teamName || data.toProject?.name}
-        </HoverLink>
+        {data.toProject ? (
+          <HoverLink href={`${PAGES.PROJECTS}/${data.toProject.id}`}>
+            {data.toProject.teamName || data.toProject.name}
+          </HoverLink>
+        ) : (
+          <HoverLink href={`${PAGES.USERS}/${data.toUser?.id}`}>
+            {data.toUser?.name}
+          </HoverLink>
+        )}
       </TableCell>
 
       {/* Status Column(s) */}

--- a/components/tables/EvaluationsTable/EvaluationsSummary/EvaluationsSummary.test.tsx
+++ b/components/tables/EvaluationsTable/EvaluationsSummary/EvaluationsSummary.test.tsx
@@ -28,6 +28,13 @@ const bothEvaluationDeadline = {
   evaluatorType: EVALUATOR_TYPE.BOTH,
 };
 
+const teamFeedbackDeadline = {
+  ...teamEvaluationDeadline,
+  id: 23,
+  name: "Team Feedback",
+  type: DEADLINE_TYPE.FEEDBACK,
+};
+
 const teamSubmission = {
   relationId: 1,
   deadline: teamEvaluationDeadline,
@@ -150,5 +157,45 @@ describe("EvaluationsSummary", () => {
       expect(teamCard.textContent).toContain("0 total expected");
       expect(bothCard.textContent).toContain("1 total expected");
     }
+  });
+
+  it("counts submitted Team feedback addressed to an adviser", () => {
+    render(
+      <EvaluationsSummary
+        deadline={teamFeedbackDeadline}
+        submissions={[
+          {
+            ...teamSubmission,
+            relationId: "F-A-101",
+            deadline: teamFeedbackDeadline,
+            toProject: undefined,
+            toUser: {
+              id: 301,
+              name: "Prof Oak",
+              email: "oak@example.com",
+            },
+            submission: {
+              id: 904,
+              deadline: teamFeedbackDeadline,
+              deadlineId: teamFeedbackDeadline.id,
+              updatedAt: "2026-03-05T10:00:00.000Z",
+              isDraft: false,
+              answers: [],
+              sections: [],
+            },
+          },
+        ]}
+        evaluationDeadlines={[teamFeedbackDeadline]}
+        evaluatorTypeFilter="Team"
+      />
+    );
+
+    const feedbackCard = screen
+      .getByText("Team Feedback")
+      .closest(".MuiCard-root");
+
+    expect(feedbackCard?.textContent).toContain("100% Complete");
+    expect(feedbackCard?.textContent).toContain("1Submitted");
+    expect(feedbackCard?.textContent).toContain("0Missing");
   });
 });

--- a/hooks/useFetch/useFetch.ts
+++ b/hooks/useFetch/useFetch.ts
@@ -88,7 +88,7 @@ const useFetch = <T>({
       cancelRequest = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [endpoint, requiresAuthorization, queryKey]);
+  }, [enabled, endpoint, requiresAuthorization, queryKey]);
 
   /* Mutate function to modify the state of the fetched data directly. */
   const mutate: Mutate<T> = async (mutator) => {

--- a/hooks/useInfiniteFetch/useInfiniteFetch.ts
+++ b/hooks/useInfiniteFetch/useInfiniteFetch.ts
@@ -74,7 +74,7 @@ export default function useInfiniteFetch<U, T>({
       fetchData();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [endpoint, queryParams, page]);
+  }, [enabled, endpoint, queryParams, page]);
 
   /* Mutate function to modify the state of the fetched data directly. */
   const mutate: Mutate<T[]> = async (mutator) => {

--- a/pages/dashboard/administrator.tsx
+++ b/pages/dashboard/administrator.tsx
@@ -60,6 +60,7 @@ import { useRouter } from "next/router";
 enum TAB {
   SUBMISSIONS = "All Teams' Milestone Submissions",
   EVALUATIONS = "All Teams' Evaluations",
+  FEEDBACK = "All Teams' Feedback",
   COLLATED = "Collated Responses",
   MANAGE_RELATIONSHIPS = "Manage Evaluation Relations",
 }
@@ -67,6 +68,7 @@ enum TAB {
 const TAB_QUERY_VALUES: Record<TAB, string> = {
   [TAB.SUBMISSIONS]: "submissions",
   [TAB.EVALUATIONS]: "evaluations",
+  [TAB.FEEDBACK]: "feedback",
   [TAB.COLLATED]: "collated",
   [TAB.MANAGE_RELATIONSHIPS]: "relations",
 };
@@ -85,6 +87,8 @@ const AdministratorDashboard: NextPage = () => {
     useState<Deadline | null>(null);
   const [selectedEvaluationsDeadline, setSelectedEvaluationsDeadline] =
     useState<Deadline | null>(null);
+  const [selectedFeedbackDeadline, setSelectedFeedbackDeadline] =
+    useState<Deadline | null>(null);
   const [selectedSubmissionStatus, setSelectedSubmissionStatus] = useState(
     SUBMISSION_STATUS.ALL
   );
@@ -94,15 +98,23 @@ const AdministratorDashboard: NextPage = () => {
   const [searchTextInput, setSearchTextInput] = useState(""); // The input value
   const [querySearch, setQuerySearch] = useState(""); // The debounced input value for searching
   const [selectedEvaluatorType, setSelectedEvaluatorType] = useState("All");
+  const [selectedFeedbackEvaluatorType, setSelectedFeedbackEvaluatorType] =
+    useState("All");
   const resetMilestonesPagination = useCallback(() => setPage(0), []);
   const resetEvaluationsPagination = useCallback(
     () => setEvaluationsPage(0),
     []
   );
+  const resetFeedbackPagination = useCallback(() => setFeedbackPage(0), []);
   const resetSubmissionPaginations = useCallback(() => {
     resetMilestonesPagination();
     resetEvaluationsPagination();
-  }, [resetEvaluationsPagination, resetMilestonesPagination]);
+    resetFeedbackPagination();
+  }, [
+    resetEvaluationsPagination,
+    resetFeedbackPagination,
+    resetMilestonesPagination,
+  ]);
 
   /** Fetching deadlines where type === Milestone and type === Evaluation */
   const { data: deadlinesResponse, status: fetchDeadlinesStatus } =
@@ -113,6 +125,7 @@ const AdministratorDashboard: NextPage = () => {
       onFetch: () => {
         setSelectedMilestoneDeadline(null);
         setSelectedEvaluationsDeadline(null);
+        setSelectedFeedbackDeadline(null);
       },
     });
 
@@ -125,6 +138,14 @@ const AdministratorDashboard: NextPage = () => {
     const filtered =
       deadlinesResponse?.deadlines.filter(
         (deadline) => deadline.type === DEADLINE_TYPE.EVALUATION
+      ) ?? [];
+    return [...filtered].sort((a, b) => a.id - b.id);
+  }, [deadlinesResponse]);
+
+  const feedbackDeadlines = useMemo(() => {
+    const filtered =
+      deadlinesResponse?.deadlines.filter(
+        (deadline) => deadline.type === DEADLINE_TYPE.FEEDBACK
       ) ?? [];
     return [...filtered].sort((a, b) => a.id - b.id);
   }, [deadlinesResponse]);
@@ -181,6 +202,33 @@ const AdministratorDashboard: NextPage = () => {
     ]
   );
 
+  /** Infinite fetching of all teams feedback submissions */
+  const memoFeedbackQueryParams = useMemo(
+    () => ({
+      cohortYear: selectedCohortYear,
+      deadlineId: selectedFeedbackDeadline
+        ? selectedFeedbackDeadline.id
+        : undefined,
+      search: querySearch,
+      limit: LIMIT,
+      submissionStatus:
+        !selectedFeedbackDeadline ||
+        selectedSubmissionStatus === SUBMISSION_STATUS.ALL
+          ? undefined
+          : selectedSubmissionStatus,
+      dropped: viewHasDropped,
+      evaluatorTypeFilter: selectedFeedbackEvaluatorType,
+    }),
+    [
+      selectedCohortYear,
+      selectedFeedbackDeadline,
+      querySearch,
+      selectedSubmissionStatus,
+      viewHasDropped,
+      selectedFeedbackEvaluatorType,
+    ]
+  );
+
   /** Infinite fetching of all teams milestone submissions without limit */
   const memoMilestoneQueryParamsSummary = useMemo(
     () => ({
@@ -219,6 +267,7 @@ const AdministratorDashboard: NextPage = () => {
           ? undefined
           : selectedSubmissionStatus,
       dropped: viewHasDropped,
+      evaluatorTypeFilter: selectedEvaluatorType,
     }),
     [
       selectedCohortYear,
@@ -226,10 +275,38 @@ const AdministratorDashboard: NextPage = () => {
       querySearch,
       selectedSubmissionStatus,
       viewHasDropped,
+      selectedEvaluatorType,
+    ]
+  );
+
+  /** Fetching of all teams feedback submissions without limit */
+  const memoFeedbackQueryParamsSummary = useMemo(
+    () => ({
+      cohortYear: selectedCohortYear,
+      deadlineId: selectedFeedbackDeadline
+        ? selectedFeedbackDeadline.id
+        : undefined,
+      search: querySearch,
+      submissionStatus:
+        !selectedFeedbackDeadline ||
+        selectedSubmissionStatus === SUBMISSION_STATUS.ALL
+          ? undefined
+          : selectedSubmissionStatus,
+      dropped: viewHasDropped,
+      evaluatorTypeFilter: selectedFeedbackEvaluatorType,
+    }),
+    [
+      selectedCohortYear,
+      selectedFeedbackDeadline,
+      querySearch,
+      selectedSubmissionStatus,
+      viewHasDropped,
+      selectedFeedbackEvaluatorType,
     ]
   );
 
   const [evaluationsPage, setEvaluationsPage] = useState(0);
+  const [feedbackPage, setFeedbackPage] = useState(0);
   useEffect(() => {
     // Reset evaluations pagination when its filters change
     setEvaluationsPage(0);
@@ -240,6 +317,17 @@ const AdministratorDashboard: NextPage = () => {
     selectedSubmissionStatus,
     viewHasDropped,
     selectedEvaluatorType,
+  ]);
+
+  useEffect(() => {
+    setFeedbackPage(0);
+  }, [
+    selectedCohortYear,
+    selectedFeedbackDeadline,
+    querySearch,
+    selectedSubmissionStatus,
+    viewHasDropped,
+    selectedFeedbackEvaluatorType,
   ]);
 
   const {
@@ -272,6 +360,23 @@ const AdministratorDashboard: NextPage = () => {
     page: evaluationsPage,
     responseToData: (response) => response.submissions,
     enabled: Boolean(selectedCohortYear),
+  });
+
+  const {
+    data: allTeamsFeedback,
+    status: fetchAllTeamsFeedbackStatus,
+    hasMore: hasMoreFeedback,
+  } = useInfiniteFetch<
+    GetAdministratorAllTeamMilestoneSubmissionsResponse,
+    PossibleSubmission
+  >({
+    endpoint: `/dashboard/administrator/feedback`,
+    queryParams: memoFeedbackQueryParams,
+    requiresAuthorization: true,
+    page: feedbackPage,
+    responseToData: (response) => response.submissions,
+    enabled:
+      Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
   });
 
   const { data: allTeamsMilestonesSummary } =
@@ -325,6 +430,15 @@ const AdministratorDashboard: NextPage = () => {
       enabled: Boolean(selectedCohortYear),
     });
 
+  const { data: allTeamsFeedbackSummary } =
+    useFetch<GetAdministratorAllTeamMilestoneSubmissionsResponse>({
+      endpoint: `/dashboard/administrator/feedback`,
+      queryParams: memoFeedbackQueryParamsSummary,
+      requiresAuthorization: true,
+      enabled:
+        Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
+    });
+
   const { data: projectsResponse } = useFetch<GetProjectsResponse>({
     endpoint: `/projects/lean?cohortYear=${selectedCohortYear}`,
     enabled: Boolean(selectedCohortYear),
@@ -360,8 +474,19 @@ const AdministratorDashboard: NextPage = () => {
     evaluationsObserver
   );
 
+  const feedbackObserver = useRef<IntersectionObserver | null>(null);
+  const feedbackBottomOfPageRef = createBottomOfPageRef(
+    isFetching(fetchAllTeamsFeedbackStatus),
+    hasMoreFeedback,
+    setFeedbackPage,
+    feedbackObserver
+  );
+
   /** Helper functions */
   const handleTabChange = (_event: React.SyntheticEvent, newValue: TAB) => {
+    if (newValue === TAB.FEEDBACK) {
+      resetFeedbackPagination();
+    }
     setSelectedTab(newValue);
     router.replace(
       {
@@ -403,6 +528,13 @@ const AdministratorDashboard: NextPage = () => {
     resetEvaluationsPagination();
   };
 
+  const handleFeedbackEvaluatorTypeChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    setSelectedFeedbackEvaluatorType(e.target.value);
+    resetFeedbackPagination();
+  };
+
   const handleSelectedEvaluationsDeadlineChange = (
     e: ChangeEvent<HTMLInputElement>
   ) => {
@@ -411,6 +543,16 @@ const AdministratorDashboard: NextPage = () => {
       newValue !== "0" ? (JSON.parse(newValue) as Deadline) : null
     );
     resetEvaluationsPagination();
+  };
+
+  const handleSelectedFeedbackDeadlineChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    const newValue = e.target.value;
+    setSelectedFeedbackDeadline(
+      newValue !== "0" ? (JSON.parse(newValue) as Deadline) : null
+    );
+    resetFeedbackPagination();
   };
 
   const handleSearchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -720,6 +862,87 @@ const AdministratorDashboard: NextPage = () => {
                     </Box>
                   </>
                 )}
+              </NoDataWrapper>
+            </Stack>
+          </LoadingWrapper>
+        </TabPanel>
+
+        <TabPanel value={TAB.FEEDBACK}>
+          <LoadingWrapper isLoading={isFetching(fetchDeadlinesStatus)}>
+            <Stack gap="0.75rem">
+              <NoDataWrapper
+                noDataCondition={!feedbackDeadlines.length}
+                fallback={
+                  <NoneFound message="No feedback deadlines found. Create one now!" />
+                }
+              >
+                <TextField
+                  id="project-cohort-select-feedback"
+                  name="cohort"
+                  label="Cohort"
+                  value={selectedCohortYear}
+                  onChange={handleCohortYearChange}
+                  select
+                  size="small"
+                  sx={{ width: "auto", minWidth: 120, alignSelf: "start" }}
+                >
+                  {cohorts &&
+                    cohorts.map(({ academicYear }) => (
+                      <MenuItem
+                        id={`${academicYear}-feedback-option`}
+                        key={academicYear}
+                        value={academicYear}
+                      >
+                        {academicYear}
+                      </MenuItem>
+                    ))}
+                </TextField>
+
+                <EvaluationsActionRow
+                  selectedEvaluationsDeadline={selectedFeedbackDeadline}
+                  handleSelectedEvaluationsDeadlineChange={
+                    handleSelectedFeedbackDeadlineChange
+                  }
+                  selectedSubmissionStatus={
+                    selectedFeedbackDeadline
+                      ? selectedSubmissionStatus
+                      : SUBMISSION_STATUS.ALL
+                  }
+                  handleSubmissionStatusChange={handleSubmissionStatusChange}
+                  searchTextInput={searchTextInput}
+                  handleSearchInputChange={handleSearchInputChange}
+                  evaluationsDeadlines={feedbackDeadlines}
+                  viewHasDropped={viewHasDropped}
+                  handleToggleViewDropped={handleToggleViewDropped}
+                  selectedCohortYear={selectedCohortYear}
+                  selectedEvaluatorType={selectedFeedbackEvaluatorType}
+                  handleEvaluatorTypeChange={handleFeedbackEvaluatorTypeChange}
+                />
+                <EvaluationsSummary
+                  deadline={selectedFeedbackDeadline}
+                  submissions={allTeamsFeedbackSummary?.submissions ?? []}
+                  evaluationDeadlines={feedbackDeadlines}
+                  evaluatorTypeFilter={selectedFeedbackEvaluatorType}
+                />
+                <EvaluationsTable
+                  deadline={selectedFeedbackDeadline}
+                  submissions={allTeamsFeedback}
+                  evaluationDeadlines={feedbackDeadlines}
+                />
+                <div ref={feedbackBottomOfPageRef} />
+                <Box
+                  sx={{
+                    display: "grid",
+                    placeItems: "center",
+                    height: "100px",
+                  }}
+                >
+                  {isFetching(fetchAllTeamsFeedbackStatus) ? (
+                    <LoadingSpinner size={50} />
+                  ) : !hasMoreFeedback ? (
+                    <Typography>No more submissions found</Typography>
+                  ) : null}
+                </Box>
               </NoDataWrapper>
             </Stack>
           </LoadingWrapper>

--- a/pages/dashboard/administrator.tsx
+++ b/pages/dashboard/administrator.tsx
@@ -375,8 +375,7 @@ const AdministratorDashboard: NextPage = () => {
     requiresAuthorization: true,
     page: feedbackPage,
     responseToData: (response) => response.submissions,
-    enabled:
-      Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
+    enabled: Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
   });
 
   const { data: allTeamsMilestonesSummary } =
@@ -435,8 +434,7 @@ const AdministratorDashboard: NextPage = () => {
       endpoint: `/dashboard/administrator/feedback`,
       queryParams: memoFeedbackQueryParamsSummary,
       requiresAuthorization: true,
-      enabled:
-        Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
+      enabled: Boolean(selectedCohortYear) && selectedTab === TAB.FEEDBACK,
     });
 
   const { data: projectsResponse } = useFetch<GetProjectsResponse>({

--- a/types/submissions.ts
+++ b/types/submissions.ts
@@ -1,10 +1,11 @@
-import { Deadline, Option, Section } from "./deadlines";
+import { Deadline, Option, Question, Section } from "./deadlines";
 import { Project } from "./projects";
 import { User } from "./users";
 
 export type Answer = {
   questionId: number;
   answer: Option;
+  question?: Question;
 };
 
 export type Submission = {


### PR DESCRIPTION
## Summary

- Add evaluator type selection when creating or editing Feedback deadlines.
- Add an administrator Feedback tab with summaries, filters, reminders, and CSV export.
- Support team and adviser Feedback rows.
- Export Feedback answers as question columns.

## Testing

- Added Feedback rendering, CSV export, and summary tests.